### PR TITLE
Remove trusted proxies around auto.ipxe:

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,26 +68,26 @@ FLAGS
   -backend-kube-namespace             [backend] an optional Kubernetes namespace override to query hardware data from, kube backend only
   -dhcp-addr                          [dhcp] local IP:Port to listen on for DHCP requests (default "0.0.0.0:67")
   -dhcp-enabled                       [dhcp] enable DHCP server (default "true")
-  -dhcp-http-ipxe-binary-url          [dhcp] HTTP ipxe binaries URL to use in DHCP packets (default "http://172.17.0.2:8080/ipxe/")
-  -dhcp-http-ipxe-script-prepend-mac  [dhcp] prepend the hardware mac address to ipxe script URL base, http://1.2.3.4/auto.ipxe -> http://1.2.3.4/40:15:ff:89:cc:0e/auto.ipxe (default "true")
-  -dhcp-http-ipxe-script-url          [dhcp] HTTP ipxe script URL to use in DHCP packets (default "http://172.17.0.2/auto.ipxe")
+  -dhcp-http-ipxe-binary-url          [dhcp] HTTP iPXE binaries URL to use in DHCP packets (default "http://172.17.0.2:8080/ipxe/")
+  -dhcp-http-ipxe-script-prepend-mac  [dhcp] prepend the hardware MAC address to iPXE script URL base, http://1.2.3.4/auto.ipxe -> http://1.2.3.4/40:15:ff:89:cc:0e/auto.ipxe (default "true")
+  -dhcp-http-ipxe-script-url          [dhcp] HTTP iPXE script URL to use in DHCP packets (default "http://172.17.0.2/auto.ipxe")
   -dhcp-iface                         [dhcp] interface to bind to for DHCP requests
   -dhcp-ip-for-packet                 [dhcp] IP address to use in DHCP packets (opt 54, etc) (default "172.17.0.2")
-  -dhcp-syslog-ip                     [dhcp] syslog server IP address to use in DHCP packets (opt 7) (default "172.17.0.2")
-  -dhcp-tftp-ip                       [dhcp] tftp server IP address to use in DHCP packets (opt 66, etc) (default "172.17.0.2:69")
+  -dhcp-syslog-ip                     [dhcp] Syslog server IP address to use in DHCP packets (opt 7) (default "172.17.0.2")
+  -dhcp-tftp-ip                       [dhcp] TFTP server IP address to use in DHCP packets (opt 66, etc) (default "172.17.0.2:69")
   -extra-kernel-args                  [http] extra set of kernel args (k=v k=v) that are appended to the kernel cmdline iPXE script
   -http-addr                          [http] local IP:Port to listen on for iPXE HTTP script requests (default "172.17.0.2:80")
   -http-ipxe-binary-enabled           [http] enable iPXE HTTP binary server (default "true")
   -http-ipxe-script-enabled           [http] enable iPXE HTTP script server (default "true")
-  -osie-url                           [http] URL where OSIE(Hook) images are located
+  -osie-url                           [http] URL where OSIE (HookOS) images are located
   -tink-server                        [http] IP:Port for the Tink server
   -tink-server-tls                    [http] use TLS for Tink server (default "false")
-  -syslog-addr                        [syslog] local IP:Port to listen on for syslog messages (default "172.17.0.2:514")
-  -syslog-enabled                     [syslog] enable syslog server(receiver) (default "true")
+  -syslog-addr                        [syslog] local IP:Port to listen on for Syslog messages (default "172.17.0.2:514")
+  -syslog-enabled                     [syslog] enable Syslog server(receiver) (default "true")
   -ipxe-script-patch                  [tftp/http] iPXE script fragment to patch into served iPXE binaries served via TFTP or HTTP
-  -tftp-addr                          [tftp] local IP:Port to listen on for iPXE tftp binary requests (default "172.17.0.2:69")
-  -tftp-enabled                       [tftp] enable iPXE tftp binary server) (default "true")
-  -tftp-timeout                       [tftp] iPXE tftp binary server requests timeout (default "5s")
+  -tftp-addr                          [tftp] local IP:Port to listen on for iPXE TFTP binary requests (default "172.17.0.2:69")
+  -tftp-enabled                       [tftp] enable iPXE TFTP binary server) (default "true")
+  -tftp-timeout                       [tftp] iPXE TFTP binary server requests timeout (default "5s")
 ```
 
 You can use NixOS shell, which will have Go and other dependencies.

--- a/README.md
+++ b/README.md
@@ -53,39 +53,41 @@ make smee
 # run Smee
 ./smee -h
 
+Smee is the DHCP and Network boot service for use in the Tinkerbell stack.
+
 USAGE
-  Run Smee server for provisioning
+  smee [flags]
 
 FLAGS
-  -log-level                  log level (debug, info) (default "info")
-  -backend-file-enabled       [backend] enable the file backend for DHCP and the HTTP iPXE script (default "false")
-  -backend-file-path          [backend] the hardware yaml file path for the file backend
-  -backend-kube-api           [backend] the Kubernetes API URL, used for in-cluster client construction, kube backend only
-  -backend-kube-config        [backend] the Kubernetes config file location, kube backend only
-  -backend-kube-enabled       [backend] enable the kubernetes backend for DHCP and the HTTP iPXE script (default "true")
-  -backend-kube-namespace     [backend] an optional Kubernetes namespace override to query hardware data from, kube backend only
-  -dhcp-addr                  [dhcp] local IP and port to listen on for DHCP requests (default "0.0.0.0:67")
-  -dhcp-enabled               [dhcp] enable DHCP server (default "true")
-  -dhcp-http-ipxe-binary-url  [dhcp] HTTP ipxe binaries URL to use in DHCP packets (default "http://172.17.0.2:8080/ipxe/")
-  -dhcp-http-ipxe-script-url  [dhcp] HTTP ipxe script URL to use in DHCP packets (default "http://172.17.0.2/auto.ipxe")
-  -dhcp-iface                 [dhcp] interface to bind to for DHCP requests
-  -dhcp-ip-for-packet         [dhcp] ip address to use in DHCP packets (opt 54, etc) (default "172.17.0.2")
-  -dhcp-syslog-ip             [dhcp] syslog server IP address to use in DHCP packets (opt 7) (default "172.17.0.2")
-  -dhcp-tftp-ip               [dhcp] tftp server IP address to use in DHCP packets (opt 66, etc) (default "172.17.0.2:69")
-  -extra-kernel-args          [http] extra set of kernel args (k=v k=v) that are appended to the kernel cmdline iPXE script
-  -http-addr                  [http] local IP and port to listen on for iPXE http script requests (default "172.17.0.2:80")
-  -http-ipxe-binary-enabled   [http] enable iPXE http binary server (default "true")
-  -http-ipxe-script-enabled   [http] enable iPXE http script server) (default "true")
-  -osie-url                   [http] url where OSIE(Hook) images are located
-  -tink-server                [http] ip:port for the Tink server
-  -tink-server-tls            [http] use TLS for Tink server (default "false")
-  -trusted-proxies            [http] comma separated list of trusted proxies
-  -syslog-addr                [syslog] local IP and port to listen on for syslog messages (default "172.17.0.2:514")
-  -syslog-enabled             [syslog] enable syslog server(receiver) (default "true")
-  -ipxe-script-patch          [tftp/http] iPXE script fragment to patch into served iPXE binaries served via TFTP or HTTP
-  -tftp-addr                  [tftp] local IP and port to listen on for iPXE tftp binary requests (default "172.17.0.2:69")
-  -tftp-enabled               [tftp] enable iPXE tftp binary server) (default "true")
-  -tftp-timeout               [tftp] iPXE tftp binary server requests timeout (default "5s")
+  -log-level                          log level (debug, info) (default "info")
+  -backend-file-enabled               [backend] enable the file backend for DHCP and the HTTP iPXE script (default "false")
+  -backend-file-path                  [backend] the hardware yaml file path for the file backend
+  -backend-kube-api                   [backend] the Kubernetes API URL, used for in-cluster client construction, kube backend only
+  -backend-kube-config                [backend] the Kubernetes config file location, kube backend only
+  -backend-kube-enabled               [backend] enable the kubernetes backend for DHCP and the HTTP iPXE script (default "true")
+  -backend-kube-namespace             [backend] an optional Kubernetes namespace override to query hardware data from, kube backend only
+  -dhcp-addr                          [dhcp] local IP:Port to listen on for DHCP requests (default "0.0.0.0:67")
+  -dhcp-enabled                       [dhcp] enable DHCP server (default "true")
+  -dhcp-http-ipxe-binary-url          [dhcp] HTTP ipxe binaries URL to use in DHCP packets (default "http://172.17.0.2:8080/ipxe/")
+  -dhcp-http-ipxe-script-prepend-mac  [dhcp] prepend the hardware mac address to ipxe script URL base, http://1.2.3.4/auto.ipxe -> http://1.2.3.4/40:15:ff:89:cc:0e/auto.ipxe (default "true")
+  -dhcp-http-ipxe-script-url          [dhcp] HTTP ipxe script URL to use in DHCP packets (default "http://172.17.0.2/auto.ipxe")
+  -dhcp-iface                         [dhcp] interface to bind to for DHCP requests
+  -dhcp-ip-for-packet                 [dhcp] IP address to use in DHCP packets (opt 54, etc) (default "172.17.0.2")
+  -dhcp-syslog-ip                     [dhcp] syslog server IP address to use in DHCP packets (opt 7) (default "172.17.0.2")
+  -dhcp-tftp-ip                       [dhcp] tftp server IP address to use in DHCP packets (opt 66, etc) (default "172.17.0.2:69")
+  -extra-kernel-args                  [http] extra set of kernel args (k=v k=v) that are appended to the kernel cmdline iPXE script
+  -http-addr                          [http] local IP:Port to listen on for iPXE HTTP script requests (default "172.17.0.2:80")
+  -http-ipxe-binary-enabled           [http] enable iPXE HTTP binary server (default "true")
+  -http-ipxe-script-enabled           [http] enable iPXE HTTP script server (default "true")
+  -osie-url                           [http] URL where OSIE(Hook) images are located
+  -tink-server                        [http] IP:Port for the Tink server
+  -tink-server-tls                    [http] use TLS for Tink server (default "false")
+  -syslog-addr                        [syslog] local IP:Port to listen on for syslog messages (default "172.17.0.2:514")
+  -syslog-enabled                     [syslog] enable syslog server(receiver) (default "true")
+  -ipxe-script-patch                  [tftp/http] iPXE script fragment to patch into served iPXE binaries served via TFTP or HTTP
+  -tftp-addr                          [tftp] local IP:Port to listen on for iPXE tftp binary requests (default "172.17.0.2:69")
+  -tftp-enabled                       [tftp] enable iPXE tftp binary server) (default "true")
+  -tftp-timeout                       [tftp] iPXE tftp binary server requests timeout (default "5s")
 ```
 
 You can use NixOS shell, which will have Go and other dependencies.
@@ -97,9 +99,9 @@ You can use NixOS shell, which will have Go and other dependencies.
 The quickest way to get started is `docker-compose up`. This will start Smee using the file backend. This uses the example Yaml file (hardware.yaml) in the `test/` directory. It also starts a client container that runs some tests.
 
 ```sh
-docker-compose up --build   # build images and start the network & services
+docker compose up --build   # build images and start the network & services
 # it's fine to hit control-C twice for fast shutdown
-docker-compose down  # stop the network & containers
+docker compose down  # stop the network & containers
 ```
 
 Alternatively you can manually run Smee by itself. It requires a few
@@ -112,17 +114,23 @@ server on their network. Best to isolate it in Docker or a VM if you're not
 sure.
 
 ```sh
+# build the binary
+make build
+
 export SMEE_OSIE_URL=<http url to the OSIE (Operating System Installation Environment) artifacts>
-# For more info on the default OSUE (Hook) artifacts, please see https://github.com/tinkerbell/hook
+# For more info on the default OSIE (Hook) artifacts, please see https://github.com/tinkerbell/hook
+export SMEE_BACKEND_KUBE_ENABLED=false
 export SMEE_BACKEND_FILE_ENABLED=true
 export SMEE_BACKEND_FILE_PATH=./test/hardware.yaml
 export SMEE_EXTRA_KERNEL_ARGS="tink_worker_image=quay.io/tinkerbell/tink-worker:latest"
 
-# By default, Smee needs to bind to low ports (67, 69, 80, 514) so it needs root.
-sudo -E ./smee
+# By default, Smee needs to bind to low ports (67, 69, 514) so it needs root.
+sudo -E ./cmd/smee/smee
 
-# or run it in a container
-# NOTE: not sure the NET_ADMIN cap is necessary
-docker run -ti --cap-add=NET_ADMIN --volume $(pwd):/smee alpine:3.14
-/smee -dhcp-addr 0.0.0.0:67
+# clean up the environment variables
+unset SMEE_OSIE_URL
+unset SMEE_BACKEND_KUBE_ENABLED
+unset SMEE_BACKEND_FILE_ENABLED
+unset SMEE_BACKEND_FILE_PATH
+unset SMEE_EXTRA_KERNEL_ARGS
 ```

--- a/cmd/smee/flag.go
+++ b/cmd/smee/flag.go
@@ -19,6 +19,10 @@ import (
 func customUsageFunc(c *ffcli.Command) string {
 	var b strings.Builder
 
+	if c.LongHelp != "" {
+		fmt.Fprintf(&b, "%s\n\n", c.LongHelp)
+	}
+
 	fmt.Fprintf(&b, "USAGE\n")
 	if c.ShortUsage != "" {
 		fmt.Fprintf(&b, "  %s\n", c.ShortUsage)
@@ -26,10 +30,6 @@ func customUsageFunc(c *ffcli.Command) string {
 		fmt.Fprintf(&b, "  %s\n", c.Name)
 	}
 	fmt.Fprintf(&b, "\n")
-
-	if c.LongHelp != "" {
-		fmt.Fprintf(&b, "%s\n\n", c.LongHelp)
-	}
 
 	if len(c.Subcommands) > 0 {
 		fmt.Fprintf(&b, "SUBCOMMANDS\n")
@@ -140,7 +140,8 @@ func newCLI(cfg *config, fs *flag.FlagSet) *ffcli.Command {
 	setFlags(cfg, fs)
 	return &ffcli.Command{
 		Name:       name,
-		ShortUsage: "Run Smee server for provisioning",
+		ShortUsage: "smee [flags]",
+		LongHelp:   "Smee is the DHCP and Network boot service for use in the Tinkerbell stack.",
 		FlagSet:    fs,
 		Options:    []ff.Option{ff.WithEnvVarPrefix(name)},
 		UsageFunc:  customUsageFunc,

--- a/cmd/smee/flag.go
+++ b/cmd/smee/flag.go
@@ -81,14 +81,14 @@ func countFlags(fs *flag.FlagSet) (n int) {
 }
 
 func syslogFlags(c *config, fs *flag.FlagSet) {
-	fs.BoolVar(&c.syslog.enabled, "syslog-enabled", true, "[syslog] enable syslog server(receiver)")
-	fs.StringVar(&c.syslog.bindAddr, "syslog-addr", detectPublicIPv4(":514"), "[syslog] local IP:Port to listen on for syslog messages")
+	fs.BoolVar(&c.syslog.enabled, "syslog-enabled", true, "[syslog] enable Syslog server(receiver)")
+	fs.StringVar(&c.syslog.bindAddr, "syslog-addr", detectPublicIPv4(":514"), "[syslog] local IP:Port to listen on for Syslog messages")
 }
 
 func tftpFlags(c *config, fs *flag.FlagSet) {
-	fs.BoolVar(&c.tftp.enabled, "tftp-enabled", true, "[tftp] enable iPXE tftp binary server)")
-	fs.StringVar(&c.tftp.bindAddr, "tftp-addr", detectPublicIPv4(":69"), "[tftp] local IP:Port to listen on for iPXE tftp binary requests")
-	fs.DurationVar(&c.tftp.timeout, "tftp-timeout", time.Second*5, "[tftp] iPXE tftp binary server requests timeout")
+	fs.BoolVar(&c.tftp.enabled, "tftp-enabled", true, "[tftp] enable iPXE TFTP binary server)")
+	fs.StringVar(&c.tftp.bindAddr, "tftp-addr", detectPublicIPv4(":69"), "[tftp] local IP:Port to listen on for iPXE TFTP binary requests")
+	fs.DurationVar(&c.tftp.timeout, "tftp-timeout", time.Second*5, "[tftp] iPXE TFTP binary server requests timeout")
 	fs.StringVar(&c.tftp.ipxeScriptPatch, "ipxe-script-patch", "", "[tftp/http] iPXE script fragment to patch into served iPXE binaries served via TFTP or HTTP")
 }
 
@@ -100,7 +100,7 @@ func ipxeHTTPScriptFlags(c *config, fs *flag.FlagSet) {
 	fs.BoolVar(&c.ipxeHTTPScript.enabled, "http-ipxe-script-enabled", true, "[http] enable iPXE HTTP script server")
 	fs.StringVar(&c.ipxeHTTPScript.bindAddr, "http-addr", detectPublicIPv4(":80"), "[http] local IP:Port to listen on for iPXE HTTP script requests")
 	fs.StringVar(&c.ipxeHTTPScript.extraKernelArgs, "extra-kernel-args", "", "[http] extra set of kernel args (k=v k=v) that are appended to the kernel cmdline iPXE script")
-	fs.StringVar(&c.ipxeHTTPScript.hookURL, "osie-url", "", "[http] URL where OSIE(Hook) images are located")
+	fs.StringVar(&c.ipxeHTTPScript.hookURL, "osie-url", "", "[http] URL where OSIE (HookOS) images are located")
 	fs.StringVar(&c.ipxeHTTPScript.tinkServer, "tink-server", "", "[http] IP:Port for the Tink server")
 	fs.BoolVar(&c.ipxeHTTPScript.tinkServerUseTLS, "tink-server-tls", false, "[http] use TLS for Tink server")
 }
@@ -110,11 +110,11 @@ func dhcpFlags(c *config, fs *flag.FlagSet) {
 	fs.StringVar(&c.dhcp.bindAddr, "dhcp-addr", "0.0.0.0:67", "[dhcp] local IP:Port to listen on for DHCP requests")
 	fs.StringVar(&c.dhcp.bindInterface, "dhcp-iface", "", "[dhcp] interface to bind to for DHCP requests")
 	fs.StringVar(&c.dhcp.ipForPacket, "dhcp-ip-for-packet", detectPublicIPv4(""), "[dhcp] IP address to use in DHCP packets (opt 54, etc)")
-	fs.StringVar(&c.dhcp.syslogIP, "dhcp-syslog-ip", detectPublicIPv4(""), "[dhcp] syslog server IP address to use in DHCP packets (opt 7)")
-	fs.StringVar(&c.dhcp.tftpIP, "dhcp-tftp-ip", detectPublicIPv4(":69"), "[dhcp] tftp server IP address to use in DHCP packets (opt 66, etc)")
-	fs.StringVar(&c.dhcp.httpIpxeBinaryURL, "dhcp-http-ipxe-binary-url", "http://"+detectPublicIPv4(":8080/ipxe/"), "[dhcp] HTTP ipxe binaries URL to use in DHCP packets")
-	fs.StringVar(&c.dhcp.httpIpxeScript.url, "dhcp-http-ipxe-script-url", "http://"+detectPublicIPv4("/auto.ipxe"), "[dhcp] HTTP ipxe script URL to use in DHCP packets")
-	fs.BoolVar(&c.dhcp.httpIpxeScript.injectMacAddress, "dhcp-http-ipxe-script-prepend-mac", true, "[dhcp] prepend the hardware mac address to ipxe script URL base, http://1.2.3.4/auto.ipxe -> http://1.2.3.4/40:15:ff:89:cc:0e/auto.ipxe")
+	fs.StringVar(&c.dhcp.syslogIP, "dhcp-syslog-ip", detectPublicIPv4(""), "[dhcp] Syslog server IP address to use in DHCP packets (opt 7)")
+	fs.StringVar(&c.dhcp.tftpIP, "dhcp-tftp-ip", detectPublicIPv4(":69"), "[dhcp] TFTP server IP address to use in DHCP packets (opt 66, etc)")
+	fs.StringVar(&c.dhcp.httpIpxeBinaryURL, "dhcp-http-ipxe-binary-url", "http://"+detectPublicIPv4(":8080/ipxe/"), "[dhcp] HTTP iPXE binaries URL to use in DHCP packets")
+	fs.StringVar(&c.dhcp.httpIpxeScript.url, "dhcp-http-ipxe-script-url", "http://"+detectPublicIPv4("/auto.ipxe"), "[dhcp] HTTP iPXE script URL to use in DHCP packets")
+	fs.BoolVar(&c.dhcp.httpIpxeScript.injectMacAddress, "dhcp-http-ipxe-script-prepend-mac", true, "[dhcp] prepend the hardware MAC address to iPXE script URL base, http://1.2.3.4/auto.ipxe -> http://1.2.3.4/40:15:ff:89:cc:0e/auto.ipxe")
 }
 
 func backendFlags(c *config, fs *flag.FlagSet) {

--- a/cmd/smee/flag_test.go
+++ b/cmd/smee/flag_test.go
@@ -77,8 +77,10 @@ func TestParser(t *testing.T) {
 
 func TestCustomUsageFunc(t *testing.T) {
 	defaultIP := detectPublicIPv4("")
-	want := fmt.Sprintf(`USAGE
-  Run Smee server for provisioning
+	want := fmt.Sprintf(`Smee is the DHCP and Network boot service for use in the Tinkerbell stack.
+
+USAGE
+  smee [flags]
 
 FLAGS
   -log-level                          log level (debug, info) (default "info")

--- a/cmd/smee/flag_test.go
+++ b/cmd/smee/flag_test.go
@@ -92,26 +92,26 @@ FLAGS
   -backend-kube-namespace             [backend] an optional Kubernetes namespace override to query hardware data from, kube backend only
   -dhcp-addr                          [dhcp] local IP:Port to listen on for DHCP requests (default "0.0.0.0:67")
   -dhcp-enabled                       [dhcp] enable DHCP server (default "true")
-  -dhcp-http-ipxe-binary-url          [dhcp] HTTP ipxe binaries URL to use in DHCP packets (default "http://%[1]v:8080/ipxe/")
-  -dhcp-http-ipxe-script-prepend-mac  [dhcp] prepend the hardware mac address to ipxe script URL base, http://1.2.3.4/auto.ipxe -> http://1.2.3.4/40:15:ff:89:cc:0e/auto.ipxe (default "true")
-  -dhcp-http-ipxe-script-url          [dhcp] HTTP ipxe script URL to use in DHCP packets (default "http://%[1]v/auto.ipxe")
+  -dhcp-http-ipxe-binary-url          [dhcp] HTTP iPXE binaries URL to use in DHCP packets (default "http://%[1]v:8080/ipxe/")
+  -dhcp-http-ipxe-script-prepend-mac  [dhcp] prepend the hardware MAC address to iPXE script URL base, http://1.2.3.4/auto.ipxe -> http://1.2.3.4/40:15:ff:89:cc:0e/auto.ipxe (default "true")
+  -dhcp-http-ipxe-script-url          [dhcp] HTTP iPXE script URL to use in DHCP packets (default "http://%[1]v/auto.ipxe")
   -dhcp-iface                         [dhcp] interface to bind to for DHCP requests
   -dhcp-ip-for-packet                 [dhcp] IP address to use in DHCP packets (opt 54, etc) (default "%[1]v")
-  -dhcp-syslog-ip                     [dhcp] syslog server IP address to use in DHCP packets (opt 7) (default "%[1]v")
-  -dhcp-tftp-ip                       [dhcp] tftp server IP address to use in DHCP packets (opt 66, etc) (default "%[1]v:69")
+  -dhcp-syslog-ip                     [dhcp] Syslog server IP address to use in DHCP packets (opt 7) (default "%[1]v")
+  -dhcp-tftp-ip                       [dhcp] TFTP server IP address to use in DHCP packets (opt 66, etc) (default "%[1]v:69")
   -extra-kernel-args                  [http] extra set of kernel args (k=v k=v) that are appended to the kernel cmdline iPXE script
   -http-addr                          [http] local IP:Port to listen on for iPXE HTTP script requests (default "%[1]v:80")
   -http-ipxe-binary-enabled           [http] enable iPXE HTTP binary server (default "true")
   -http-ipxe-script-enabled           [http] enable iPXE HTTP script server (default "true")
-  -osie-url                           [http] URL where OSIE(Hook) images are located
+  -osie-url                           [http] URL where OSIE (HookOS) images are located
   -tink-server                        [http] IP:Port for the Tink server
   -tink-server-tls                    [http] use TLS for Tink server (default "false")
-  -syslog-addr                        [syslog] local IP:Port to listen on for syslog messages (default "%[1]v:514")
-  -syslog-enabled                     [syslog] enable syslog server(receiver) (default "true")
+  -syslog-addr                        [syslog] local IP:Port to listen on for Syslog messages (default "%[1]v:514")
+  -syslog-enabled                     [syslog] enable Syslog server(receiver) (default "true")
   -ipxe-script-patch                  [tftp/http] iPXE script fragment to patch into served iPXE binaries served via TFTP or HTTP
-  -tftp-addr                          [tftp] local IP:Port to listen on for iPXE tftp binary requests (default "%[1]v:69")
-  -tftp-enabled                       [tftp] enable iPXE tftp binary server) (default "true")
-  -tftp-timeout                       [tftp] iPXE tftp binary server requests timeout (default "5s")
+  -tftp-addr                          [tftp] local IP:Port to listen on for iPXE TFTP binary requests (default "%[1]v:69")
+  -tftp-enabled                       [tftp] enable iPXE TFTP binary server) (default "true")
+  -tftp-timeout                       [tftp] iPXE TFTP binary server requests timeout (default "5s")
 `, defaultIP)
 
 	c := &config{}

--- a/cmd/smee/flag_test.go
+++ b/cmd/smee/flag_test.go
@@ -34,7 +34,10 @@ func TestParser(t *testing.T) {
 			syslogIP:          "192.168.2.4",
 			tftpIP:            "192.168.2.4:69",
 			httpIpxeBinaryURL: "http://192.168.2.4:8080/ipxe/",
-			httpIpxeScriptURL: "http://192.168.2.4/auto.ipxe",
+			httpIpxeScript: httpIpxeScript{
+				url:              "http://192.168.2.4/auto.ipxe",
+				injectMacAddress: true,
+			},
 		},
 		logLevel: "info",
 		backends: dhcpBackends{
@@ -65,6 +68,7 @@ func TestParser(t *testing.T) {
 		cmp.AllowUnexported(ipxeHTTPScript{}),
 		cmp.AllowUnexported(dhcpConfig{}),
 		cmp.AllowUnexported(dhcpBackends{}),
+		cmp.AllowUnexported(httpIpxeScript{}),
 	}
 	if diff := cmp.Diff(want, got, opts); diff != "" {
 		t.Fatal(diff)
@@ -77,35 +81,35 @@ func TestCustomUsageFunc(t *testing.T) {
   Run Smee server for provisioning
 
 FLAGS
-  -log-level                  log level (debug, info) (default "info")
-  -backend-file-enabled       [backend] enable the file backend for DHCP and the HTTP iPXE script (default "false")
-  -backend-file-path          [backend] the hardware yaml file path for the file backend
-  -backend-kube-api           [backend] the Kubernetes API URL, used for in-cluster client construction, kube backend only
-  -backend-kube-config        [backend] the Kubernetes config file location, kube backend only
-  -backend-kube-enabled       [backend] enable the kubernetes backend for DHCP and the HTTP iPXE script (default "true")
-  -backend-kube-namespace     [backend] an optional Kubernetes namespace override to query hardware data from, kube backend only
-  -dhcp-addr                  [dhcp] local IP:Port to listen on for DHCP requests (default "0.0.0.0:67")
-  -dhcp-enabled               [dhcp] enable DHCP server (default "true")
-  -dhcp-http-ipxe-binary-url  [dhcp] HTTP ipxe binaries URL to use in DHCP packets (default "http://%[1]v:8080/ipxe/")
-  -dhcp-http-ipxe-script-url  [dhcp] HTTP ipxe script URL to use in DHCP packets (default "http://%[1]v/auto.ipxe")
-  -dhcp-iface                 [dhcp] interface to bind to for DHCP requests
-  -dhcp-ip-for-packet         [dhcp] IP address to use in DHCP packets (opt 54, etc) (default "%[1]v")
-  -dhcp-syslog-ip             [dhcp] syslog server IP address to use in DHCP packets (opt 7) (default "%[1]v")
-  -dhcp-tftp-ip               [dhcp] tftp server IP address to use in DHCP packets (opt 66, etc) (default "%[1]v:69")
-  -extra-kernel-args          [http] extra set of kernel args (k=v k=v) that are appended to the kernel cmdline iPXE script
-  -http-addr                  [http] local IP:Port to listen on for iPXE HTTP script requests (default "%[1]v:80")
-  -http-ipxe-binary-enabled   [http] enable iPXE HTTP binary server (default "true")
-  -http-ipxe-script-enabled   [http] enable iPXE HTTP script server (default "true")
-  -osie-url                   [http] URL where OSIE(Hook) images are located
-  -tink-server                [http] IP:Port for the Tink server
-  -tink-server-tls            [http] use TLS for Tink server (default "false")
-  -trusted-proxies            [http] comma separated list of trusted proxies in CIDR notation
-  -syslog-addr                [syslog] local IP:Port to listen on for syslog messages (default "%[1]v:514")
-  -syslog-enabled             [syslog] enable syslog server(receiver) (default "true")
-  -ipxe-script-patch          [tftp/http] iPXE script fragment to patch into served iPXE binaries served via TFTP or HTTP
-  -tftp-addr                  [tftp] local IP:Port to listen on for iPXE tftp binary requests (default "%[1]v:69")
-  -tftp-enabled               [tftp] enable iPXE tftp binary server) (default "true")
-  -tftp-timeout               [tftp] iPXE tftp binary server requests timeout (default "5s")
+  -log-level                          log level (debug, info) (default "info")
+  -backend-file-enabled               [backend] enable the file backend for DHCP and the HTTP iPXE script (default "false")
+  -backend-file-path                  [backend] the hardware yaml file path for the file backend
+  -backend-kube-api                   [backend] the Kubernetes API URL, used for in-cluster client construction, kube backend only
+  -backend-kube-config                [backend] the Kubernetes config file location, kube backend only
+  -backend-kube-enabled               [backend] enable the kubernetes backend for DHCP and the HTTP iPXE script (default "true")
+  -backend-kube-namespace             [backend] an optional Kubernetes namespace override to query hardware data from, kube backend only
+  -dhcp-addr                          [dhcp] local IP:Port to listen on for DHCP requests (default "0.0.0.0:67")
+  -dhcp-enabled                       [dhcp] enable DHCP server (default "true")
+  -dhcp-http-ipxe-binary-url          [dhcp] HTTP ipxe binaries URL to use in DHCP packets (default "http://%[1]v:8080/ipxe/")
+  -dhcp-http-ipxe-script-prepend-mac  [dhcp] prepend the hardware mac address to ipxe script URL base, http://1.2.3.4/auto.ipxe -> http://1.2.3.4/40:15:ff:89:cc:0e/auto.ipxe (default "true")
+  -dhcp-http-ipxe-script-url          [dhcp] HTTP ipxe script URL to use in DHCP packets (default "http://%[1]v/auto.ipxe")
+  -dhcp-iface                         [dhcp] interface to bind to for DHCP requests
+  -dhcp-ip-for-packet                 [dhcp] IP address to use in DHCP packets (opt 54, etc) (default "%[1]v")
+  -dhcp-syslog-ip                     [dhcp] syslog server IP address to use in DHCP packets (opt 7) (default "%[1]v")
+  -dhcp-tftp-ip                       [dhcp] tftp server IP address to use in DHCP packets (opt 66, etc) (default "%[1]v:69")
+  -extra-kernel-args                  [http] extra set of kernel args (k=v k=v) that are appended to the kernel cmdline iPXE script
+  -http-addr                          [http] local IP:Port to listen on for iPXE HTTP script requests (default "%[1]v:80")
+  -http-ipxe-binary-enabled           [http] enable iPXE HTTP binary server (default "true")
+  -http-ipxe-script-enabled           [http] enable iPXE HTTP script server (default "true")
+  -osie-url                           [http] URL where OSIE(Hook) images are located
+  -tink-server                        [http] IP:Port for the Tink server
+  -tink-server-tls                    [http] use TLS for Tink server (default "false")
+  -syslog-addr                        [syslog] local IP:Port to listen on for syslog messages (default "%[1]v:514")
+  -syslog-enabled                     [syslog] enable syslog server(receiver) (default "true")
+  -ipxe-script-patch                  [tftp/http] iPXE script fragment to patch into served iPXE binaries served via TFTP or HTTP
+  -tftp-addr                          [tftp] local IP:Port to listen on for iPXE tftp binary requests (default "%[1]v:69")
+  -tftp-enabled                       [tftp] enable iPXE tftp binary server) (default "true")
+  -tftp-timeout                       [tftp] iPXE tftp binary server requests timeout (default "5s")
 `, defaultIP)
 
 	c := &config{}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,8 +29,9 @@ services:
         ipv4_address: 192.168.99.42
     mac_address: 02:00:00:00:00:01
     environment:
-      SMEE_TINK_SERVER: tinkerbell.tinkerbell:42113
-      SMEE_BACKEND_FILE: true
+      SMEE_TINK_SERVER: tink-server:42113
+      SMEE_BACKEND_KUBE_ENABLED: false
+      SMEE_BACKEND_FILE_ENABLED: true
       SMEE_BACKEND_FILE_PATH: /hardware.yaml
       SMEE_OSIE_URL: "http://192.168.8.5/osie/artifacts/"
       OTEL_EXPORTER_OTLP_ENDPOINT: otel-collector:4317

--- a/go.mod
+++ b/go.mod
@@ -8,10 +8,9 @@ require (
 	github.com/go-logr/zapr v1.2.4
 	github.com/google/go-cmp v0.6.0
 	github.com/insomniacslk/dhcp v0.0.0-20230908212754-65c27093e38a
-	github.com/packethost/xff v0.0.0-20190305172552-d3e9190c41b3
 	github.com/peterbourgon/ff/v3 v3.4.0
 	github.com/prometheus/client_golang v1.17.0
-	github.com/tinkerbell/dhcp v0.0.0-20231023182819-60610e3eff8d
+	github.com/tinkerbell/dhcp v0.0.0-20231102180731-28d9c2fedcbf
 	github.com/tinkerbell/ipxedust v0.0.0-20231006181752-2042f6b1aad3
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.45.0
 	go.opentelemetry.io/otel v1.19.0

--- a/go.sum
+++ b/go.sum
@@ -121,8 +121,6 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/onsi/ginkgo/v2 v2.11.0 h1:WgqUCUt/lT6yXoQ8Wef0fsNn5cAuMK7+KT9UFRz2tcU=
 github.com/onsi/gomega v1.27.10 h1:naR28SdDFlqrG6kScpT8VWpu1xWY5nJRCF3XaYyBjhI=
-github.com/packethost/xff v0.0.0-20190305172552-d3e9190c41b3 h1:QcUVLV3NdkCVv4DxQkhgkxTsRvuXn+ZuSqD93mQYouc=
-github.com/packethost/xff v0.0.0-20190305172552-d3e9190c41b3/go.mod h1:nt3WBqCaQsbnxYVBoB4pF+F584z9PjdSVm29iu4gIBg=
 github.com/peterbourgon/ff/v3 v3.4.0 h1:QBvM/rizZM1cB0p0lGMdmR7HxZeI/ZrBWB4DqLkMUBc=
 github.com/peterbourgon/ff/v3 v3.4.0/go.mod h1:zjJVUhx+twciwfDl0zBcFzl4dW8axCRyXE/eKY9RztQ=
 github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5 h1:Ii+DKncOVM8Cu1Hc+ETb5K+23HdAMvESYE3ZJ5b5cMI=
@@ -160,8 +158,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
-github.com/tinkerbell/dhcp v0.0.0-20231023182819-60610e3eff8d h1:7X37qNeMa58SMzGoUhn0ENw8wmCey9rHJZ3CFazmR+I=
-github.com/tinkerbell/dhcp v0.0.0-20231023182819-60610e3eff8d/go.mod h1:npx5LbQGP/hZ2aXBof2MOzhVmoYdeMihCIUcVewXYx8=
+github.com/tinkerbell/dhcp v0.0.0-20231102180731-28d9c2fedcbf h1:+yiWT52hxnme29qVt1Q5VKQ0UWe03f29xkcC+wJg7CE=
+github.com/tinkerbell/dhcp v0.0.0-20231102180731-28d9c2fedcbf/go.mod h1:Z4FZZhG9gcPdYz4GwZT5xj/LtwUnKUVJVG/MCwxJes4=
 github.com/tinkerbell/ipxedust v0.0.0-20231006181752-2042f6b1aad3 h1:g6Gs2/UxTDBnPTL6jKXCNWRR+BFZYRX84yAiYfZ/1/g=
 github.com/tinkerbell/ipxedust v0.0.0-20231006181752-2042f6b1aad3/go.mod h1:hso2K3ctn7aXhQFjpcBAySRQmEzOLp4woqfc6smZGeI=
 github.com/tinkerbell/tink v0.9.0 h1:W7X/OEmhyYXE/kPVu1U31fpugVHoc2qsAvBtsZ7mkDg=

--- a/ipxe/http/middleware.go
+++ b/ipxe/http/middleware.go
@@ -28,14 +28,14 @@ func (h *loggingMiddleware) ServeHTTP(w http.ResponseWriter, req *http.Request) 
 		log = false
 	}
 	if log {
-		h.log.V(1).Info("request", "method", method, "uri", uri, "client", client, "event", "sr")
+		h.log.V(1).Info("request", "method", method, "uri", uri, "client", client)
 	}
 
 	res := &responseWriter{ResponseWriter: w}
 	h.handler.ServeHTTP(res, req) // process the request
 
 	if log {
-		h.log.Info("response", "method", method, "uri", uri, "client", client, "duration", time.Since(start), "status", res.statusCode, "event", "ss")
+		h.log.Info("response", "method", method, "uri", uri, "client", client, "duration", time.Since(start), "status", res.statusCode)
 	}
 }
 

--- a/ipxe/script/ipxe_test.go
+++ b/ipxe/script/ipxe_test.go
@@ -31,7 +31,7 @@ func TestCustomScript(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			d := Data{MACAddress: net.HardwareAddr{0x00, 0x01, 0x02, 0x03, 0x04, 0x05}, IPXEScript: tt.ipxeScript, IPXEScriptURL: u}
+			d := data{MACAddress: net.HardwareAddr{0x00, 0x01, 0x02, 0x03, 0x04, 0x05}, IPXEScript: tt.ipxeScript, IPXEScriptURL: u}
 			got, err := h.customScript(d)
 			if err != nil && !tt.shouldErr {
 				t.Fatal(err)
@@ -69,7 +69,7 @@ boot
 			h := &Handler{
 				OSIEURL: "http://127.1.1.1",
 			}
-			d := Data{MACAddress: net.HardwareAddr{0x00, 0x01, 0x02, 0x03, 0x04, 0x05}, VLANID: "1234", Facility: "onprem", Arch: "x86_64"}
+			d := data{MACAddress: net.HardwareAddr{0x00, 0x01, 0x02, 0x03, 0x04, 0x05}, VLANID: "1234", Facility: "onprem", Arch: "x86_64"}
 			sp := trace.SpanFromContext(context.Background())
 			got, err := h.defaultScript(sp, d)
 			if err != nil {


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->

This moves from using IP auth via the source IP address and the trusted proxies cli flag/env var to using the MAC address in the URL in order to determine the Hardware to lookup when serving the auto.ipxe. For example: `http://192.168.2.3/40:15:ff:89:cc:0e/auto.ipxe`

This opens up the `auto.ipxe` script to be able to be served across network address translation (NAT) layers and simplifies the deployment by not having to deal with the X-Forwarded-For (XFF) header.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
