### PR TITLE
Add TFTP blocksize flag:

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ FLAGS
   -syslog-enabled                     [syslog] enable Syslog server(receiver) (default "true")
   -ipxe-script-patch                  [tftp/http] iPXE script fragment to patch into served iPXE binaries served via TFTP or HTTP
   -tftp-addr                          [tftp] local IP:Port to listen on for iPXE TFTP binary requests (default "172.17.0.2:69")
+  -tftp-block-size                    [tftp] TFTP block size a value between 512 (the default block size for TFTP) and 65456 (the max size a UDP packet payload can be) (default "512")
   -tftp-enabled                       [tftp] enable iPXE TFTP binary server) (default "true")
   -tftp-timeout                       [tftp] iPXE TFTP binary server requests timeout (default "5s")
 ```

--- a/cmd/smee/flag.go
+++ b/cmd/smee/flag.go
@@ -90,6 +90,7 @@ func tftpFlags(c *config, fs *flag.FlagSet) {
 	fs.StringVar(&c.tftp.bindAddr, "tftp-addr", detectPublicIPv4(":69"), "[tftp] local IP:Port to listen on for iPXE TFTP binary requests")
 	fs.DurationVar(&c.tftp.timeout, "tftp-timeout", time.Second*5, "[tftp] iPXE TFTP binary server requests timeout")
 	fs.StringVar(&c.tftp.ipxeScriptPatch, "ipxe-script-patch", "", "[tftp/http] iPXE script fragment to patch into served iPXE binaries served via TFTP or HTTP")
+	fs.IntVar(&c.tftp.blockSize, "tftp-block-size", 512, "[tftp] TFTP block size a value between 512 (the default block size for TFTP) and 65456 (the max size a UDP packet payload can be)")
 }
 
 func ipxeHTTPBinaryFlags(c *config, fs *flag.FlagSet) {

--- a/cmd/smee/flag_test.go
+++ b/cmd/smee/flag_test.go
@@ -16,9 +16,10 @@ func TestParser(t *testing.T) {
 			bindAddr: "192.168.2.4:514",
 		},
 		tftp: tftp{
-			enabled:  true,
-			timeout:  5 * time.Second,
-			bindAddr: "192.168.2.4:69",
+			blockSize: 512,
+			enabled:   true,
+			timeout:   5 * time.Second,
+			bindAddr:  "192.168.2.4:69",
 		},
 		ipxeHTTPBinary: ipxeHTTPBinary{
 			enabled: true,
@@ -111,6 +112,7 @@ FLAGS
   -syslog-enabled                     [syslog] enable Syslog server(receiver) (default "true")
   -ipxe-script-patch                  [tftp/http] iPXE script fragment to patch into served iPXE binaries served via TFTP or HTTP
   -tftp-addr                          [tftp] local IP:Port to listen on for iPXE TFTP binary requests (default "%[1]v:69")
+  -tftp-block-size                    [tftp] TFTP block size a value between 512 (the default block size for TFTP) and 65456 (the max size a UDP packet payload can be) (default "512")
   -tftp-enabled                       [tftp] enable iPXE TFTP binary server) (default "true")
   -tftp-timeout                       [tftp] iPXE TFTP binary server requests timeout (default "5s")
 `, defaultIP)

--- a/cmd/smee/main.go
+++ b/cmd/smee/main.go
@@ -61,10 +61,11 @@ type syslogConfig struct {
 }
 
 type tftp struct {
-	enabled         bool
 	bindAddr        string
-	timeout         time.Duration
+	blockSize       int
+	enabled         bool
 	ipxeScriptPatch string
+	timeout         time.Duration
 }
 
 type ipxeHTTPBinary struct {
@@ -144,10 +145,11 @@ func main() {
 		tftpServer.EnableTFTPSinglePort = true
 		if ip, err := netip.ParseAddrPort(cfg.tftp.bindAddr); err == nil {
 			tftpServer.TFTP = ipxedust.ServerSpec{
-				Disabled: false,
-				Addr:     ip,
-				Timeout:  cfg.tftp.timeout,
-				Patch:    []byte(cfg.tftp.ipxeScriptPatch),
+				Disabled:  false,
+				Addr:      ip,
+				Timeout:   cfg.tftp.timeout,
+				Patch:     []byte(cfg.tftp.ipxeScriptPatch),
+				BlockSize: cfg.tftp.blockSize,
 			}
 			// start the ipxe binary tftp server
 			log.Info("starting tftp server", "bind_addr", cfg.tftp.bindAddr)


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
Allows customizing TFTP blocksize at runtime.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #368 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
