### PR TITLE
Add auto discovery of trusted proxies in Kubernetes, relays and giaddr fix:

### DIFF
--- a/cmd/smee/backend.go
+++ b/cmd/smee/backend.go
@@ -125,7 +125,7 @@ func combinedCIDRs(ctx context.Context, l logr.Logger, c *corev1client.CoreV1Cli
 // This will get the podCIDR from each node in the cluster, not the entire cluster podCIDR. If a cluster grows after this is run,
 // the new nodes will not be included until this func is run again.
 // This should be used in conjunction with ClusterPodCIDR to be as complete and cross distribution compatible as possible.
-func perNodePodCIDRs(ctx context.Context, c *corev1client.CoreV1Client) ([]string, error) {
+func perNodePodCIDRs(ctx context.Context, c corev1client.CoreV1Interface) ([]string, error) {
 	ns, err := c.Nodes().List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, err
@@ -142,7 +142,7 @@ func perNodePodCIDRs(ctx context.Context, c *corev1client.CoreV1Client) ([]strin
 // clusterPodCIDR returns the CIDR Range for Pods in cluster. This is the total podCIDR as compared to the per node podCIDR.
 // Some Kubernetes distributions do not run a kube-controller-manager pod, so this func should be used in conjunction with PerNodePodCIDRs
 // to be as complete and cross distribution compatible as possible.
-func clusterPodCIDR(ctx context.Context, c *corev1client.CoreV1Client) ([]string, error) {
+func clusterPodCIDR(ctx context.Context, c corev1client.CoreV1Interface) ([]string, error) {
 	// https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/
 	pods, err := c.Pods("kube-system").List(ctx, metav1.ListOptions{
 		LabelSelector: "component=kube-controller-manager",

--- a/cmd/smee/backend.go
+++ b/cmd/smee/backend.go
@@ -2,11 +2,15 @@ package main
 
 import (
 	"context"
+	"strings"
 
 	"github.com/go-logr/logr"
 	"github.com/tinkerbell/dhcp/backend/file"
 	"github.com/tinkerbell/dhcp/backend/kube"
 	"github.com/tinkerbell/dhcp/handler"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
@@ -27,7 +31,7 @@ type File struct {
 	Enabled  bool
 }
 
-func (k *Kube) Backend(ctx context.Context) (handler.BackendReader, error) {
+func (k *Kube) getClient() (*rest.Config, error) {
 	ccfg := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 		&clientcmd.ClientConfigLoadingRules{
 			ExplicitPath: k.ConfigFilePath,
@@ -47,6 +51,15 @@ func (k *Kube) Backend(ctx context.Context) (handler.BackendReader, error) {
 		return nil, err
 	}
 
+	return config, nil
+}
+
+func (k *Kube) backend(ctx context.Context) (handler.BackendReader, error) {
+	config, err := k.getClient()
+	if err != nil {
+		return nil, err
+	}
+
 	kb, err := kube.NewBackend(config)
 	if err != nil {
 		return nil, err
@@ -62,7 +75,7 @@ func (k *Kube) Backend(ctx context.Context) (handler.BackendReader, error) {
 	return kb, nil
 }
 
-func (s *File) Backend(ctx context.Context, logger logr.Logger) (handler.BackendReader, error) {
+func (s *File) backend(ctx context.Context, logger logr.Logger) (handler.BackendReader, error) {
 	f, err := file.NewWatcher(logger, s.FilePath)
 	if err != nil {
 		return nil, err
@@ -71,4 +84,83 @@ func (s *File) Backend(ctx context.Context, logger logr.Logger) (handler.Backend
 	go f.Start(ctx)
 
 	return f, nil
+}
+
+// discoverTrustedProxies will use the Kubernetes client to discover the CIDR Ranges for Pods in cluster.
+func (k *Kube) discoverTrustedProxies(ctx context.Context, l logr.Logger, trustedProxies []string) []string {
+	config, err := k.getClient()
+	if err != nil {
+		l.Error(err, "failed to get Kubernetes client config")
+		return nil
+	}
+	c, err := corev1client.NewForConfig(config)
+	if err != nil {
+		l.Error(err, "failed to create Kubernetes client")
+		return nil
+	}
+
+	return combinedCIDRs(ctx, l, c, trustedProxies)
+}
+
+// combinedCIDRs returns the CIDR Ranges for Pods in cluster. Not all Kubernetes distributions provide a way to discover the entire podCIDR.
+// Some distributions just provide the podCIDRs assigned to each node. combinedCIDRs tries all known locations where pod CIDRs might exist.
+// For example, if a cluster has 3 nodes, each with a /24 podCIDR, and the cluster has a /16 podCIDR, combinedCIDRs will return 4 CIDR ranges.
+func combinedCIDRs(ctx context.Context, l logr.Logger, c *corev1client.CoreV1Client, trustedProxies []string) []string {
+	if podCIDRS, err := perNodePodCIDRs(ctx, c); err == nil {
+		trustedProxies = append(trustedProxies, podCIDRS...)
+	} else {
+		l.V(1).Info("failed to get per node podCIDRs", "err", err)
+	}
+
+	if clusterCIDR, err := clusterPodCIDR(ctx, c); err == nil {
+		trustedProxies = append(trustedProxies, clusterCIDR...)
+	} else {
+		l.V(1).Info("failed to get cluster wide podCIDR", "err", err)
+	}
+
+	return trustedProxies
+}
+
+// perNodePodCIDRs returns the CIDR Range for Pods on each node. This is the per node podCIDR as compared to the total podCIDR.
+// This will get the podCIDR from each node in the cluster, not the entire cluster podCIDR. If a cluster grows after this is run,
+// the new nodes will not be included until this func is run again.
+// This should be used in conjunction with ClusterPodCIDR to be as complete and cross distribution compatible as possible.
+func perNodePodCIDRs(ctx context.Context, c *corev1client.CoreV1Client) ([]string, error) {
+	ns, err := c.Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	var trustedProxies []string
+	for _, n := range ns.Items {
+		trustedProxies = append(trustedProxies, n.Spec.PodCIDRs...)
+	}
+
+	return trustedProxies, nil
+}
+
+// clusterPodCIDR returns the CIDR Range for Pods in cluster. This is the total podCIDR as compared to the per node podCIDR.
+// Some Kubernetes distributions do not run a kube-controller-manager pod, so this func should be used in conjunction with PerNodePodCIDRs
+// to be as complete and cross distribution compatible as possible.
+func clusterPodCIDR(ctx context.Context, c *corev1client.CoreV1Client) ([]string, error) {
+	// https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/
+	pods, err := c.Pods("kube-system").List(ctx, metav1.ListOptions{
+		LabelSelector: "component=kube-controller-manager",
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var trustedProxies []string
+	for _, p := range pods.Items {
+		for _, c := range p.Spec.Containers {
+			for _, e := range c.Command {
+				if strings.HasPrefix(e, "--cluster-cidr") {
+					trustedProxies = append(trustedProxies, strings.Split(e, "=")[1])
+				}
+			}
+		}
+	}
+
+	return trustedProxies, nil
 }

--- a/cmd/smee/backend.go
+++ b/cmd/smee/backend.go
@@ -107,7 +107,7 @@ func (k *Kube) discoverTrustedProxies(ctx context.Context, l logr.Logger, truste
 // For example, if a cluster has 3 nodes, each with a /24 podCIDR, and the cluster has a /16 podCIDR, combinedCIDRs will return 4 CIDR ranges.
 func combinedCIDRs(ctx context.Context, l logr.Logger, c corev1client.CoreV1Interface, trustedProxies []string) []string {
 	var tp []string
-	copy(tp, trustedProxies)
+	tp = append(tp, trustedProxies...)
 	if podCIDRS, err := perNodePodCIDRs(ctx, c); err == nil {
 		tp = append(tp, podCIDRS...)
 	} else {

--- a/cmd/smee/backend_test.go
+++ b/cmd/smee/backend_test.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/google/go-cmp/cmp"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestClusterPodCIDR(t *testing.T) {
+	tests := map[string]struct {
+		spec []runtime.Object
+		want []string
+	}{
+		"no podCIDR": {},
+		"podCIDR": {
+			spec: []runtime.Object{
+				&v1.PodList{
+					Items: []v1.Pod{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Labels: map[string]string{
+									"component": "kube-controller-manager",
+								},
+								Namespace: "kube-system",
+							},
+							Spec: v1.PodSpec{
+								Containers: []v1.Container{
+									{
+										Command: []string{
+											"kube-controller-manager",
+											"--allocate-node-cidrs=true",
+											"--authentication-kubeconfig=/etc/kubernetes/controller-manager.conf",
+											"--authorization-kubeconfig=/etc/kubernetes/controller-manager.conf",
+											"--bind-address=127.0.0.1",
+											"--client-ca-file=/etc/kubernetes/pki/ca.crt",
+											"--cluster-cidr=10.244.0.0/16",
+											"--cluster-name=kubernetes",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []string{"10.244.0.0/16"},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			c := fake.NewSimpleClientset(test.spec...)
+			got, err := clusterPodCIDR(context.Background(), c.CoreV1())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(got, test.want); diff != "" {
+				t.Fatalf("unexpected result (+want -got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestPerNodePodCIDRs(t *testing.T) {
+	tests := map[string]struct {
+		spec []runtime.Object
+		want []string
+	}{
+		"no podCIDR": {},
+		"podCIDR": {
+			spec: []runtime.Object{
+				&v1.NodeList{
+					Items: []v1.Node{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "node1",
+							},
+							Spec: v1.NodeSpec{
+								PodCIDRs: []string{"10.42.0.0/24"},
+							},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "node2",
+							},
+							Spec: v1.NodeSpec{
+								PodCIDRs: []string{"10.42.1.0/24"},
+							},
+						},
+					},
+				},
+			},
+			want: []string{"10.42.0.0/24", "10.42.1.0/24"},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			c := fake.NewSimpleClientset(test.spec...)
+			got, err := perNodePodCIDRs(context.Background(), c.CoreV1())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(got, test.want); diff != "" {
+				t.Fatalf("unexpected result (+want -got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestCombinedCIDRs(t *testing.T) {
+	tests := map[string]struct {
+		spec []runtime.Object
+		want []string
+	}{
+		"no podCIDR": {},
+		"podCIDR": {
+			spec: []runtime.Object{
+				&v1.NodeList{
+					Items: []v1.Node{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "node1",
+							},
+							Spec: v1.NodeSpec{
+								PodCIDRs: []string{"10.42.0.0/24"},
+							},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "node2",
+							},
+							Spec: v1.NodeSpec{
+								PodCIDRs: []string{"10.42.1.0/24"},
+							},
+						},
+					},
+				},
+				&v1.PodList{
+					Items: []v1.Pod{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Labels: map[string]string{
+									"component": "kube-controller-manager",
+								},
+								Namespace: "kube-system",
+							},
+							Spec: v1.PodSpec{
+								Containers: []v1.Container{
+									{
+										Command: []string{
+											"kube-controller-manager",
+											"--allocate-node-cidrs=true",
+											"--authentication-kubeconfig=/etc/kubernetes/controller-manager.conf",
+											"--authorization-kubeconfig=/etc/kubernetes/controller-manager.conf",
+											"--bind-address=127.0.0.1",
+											"--client-ca-file=/etc/kubernetes/pki/ca.crt",
+											"--cluster-cidr=10.244.0.0/16",
+											"--cluster-name=kubernetes",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []string{"10.42.0.0/24", "10.42.1.0/24", "10.244.0.0/16"},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			c := fake.NewSimpleClientset(test.spec...)
+			got := combinedCIDRs(context.Background(), logr.Discard(), c.CoreV1(), nil)
+			if diff := cmp.Diff(got, test.want); diff != "" {
+				t.Fatalf("unexpected result (+want -got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/cmd/smee/backend_test.go
+++ b/cmd/smee/backend_test.go
@@ -182,3 +182,70 @@ func TestCombinedCIDRs(t *testing.T) {
 		})
 	}
 }
+
+func TestDiscoverTrustedProxies(t *testing.T) {
+	t.Skip("dont think i can mock this")
+	tests := map[string]struct {
+		spec []runtime.Object
+		want []string
+	}{
+		"no podCIDR": {},
+		"podCIDR": {
+			spec: []runtime.Object{
+				&v1.NodeList{
+					Items: []v1.Node{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "node1",
+							},
+							Spec: v1.NodeSpec{
+								PodCIDRs: []string{"10.42.0.0/24"},
+							},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "node2",
+							},
+							Spec: v1.NodeSpec{
+								PodCIDRs: []string{"10.42.1.0/24"},
+							},
+						},
+					},
+				},
+				&v1.PodList{
+					Items: []v1.Pod{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Labels: map[string]string{
+									"component": "kube-controller-manager",
+								},
+								Namespace: "kube-system",
+							},
+							Spec: v1.PodSpec{
+								Containers: []v1.Container{
+									{
+										Command: []string{
+											"kube-controller-manager",
+											"--allocate-node-cidrs=true",
+											"--authentication-kubeconfig=/etc/kubernetes/controller-manager.conf",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []string{"10.42.1.0/24", "10.42.0.0/24"},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			k := &Kube{}
+			got := k.discoverTrustedProxies(context.Background(), logr.Discard(), nil)
+			if diff := cmp.Diff(got, test.want); diff != "" {
+				t.Fatalf("unexpected result (+want -got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/cmd/smee/flag.go
+++ b/cmd/smee/flag.go
@@ -102,6 +102,7 @@ func ipxeHTTPScriptFlags(c *config, fs *flag.FlagSet) {
 	fs.StringVar(&c.ipxeHTTPScript.bindAddr, "http-addr", detectPublicIPv4(":80"), "[http] local IP:Port to listen on for iPXE HTTP script requests")
 	fs.StringVar(&c.ipxeHTTPScript.extraKernelArgs, "extra-kernel-args", "", "[http] extra set of kernel args (k=v k=v) that are appended to the kernel cmdline iPXE script")
 	fs.StringVar(&c.ipxeHTTPScript.trustedProxies, "trusted-proxies", "", "[http] comma separated list of trusted proxies in CIDR notation")
+	fs.BoolVar(&c.ipxeHTTPScript.disableDiscoverTrustedProxies, "disable-discover-trusted-proxies", false, "[http] disable discovery of trusted proxies from Kubernetes, only available for the Kubernetes backend")
 	fs.StringVar(&c.ipxeHTTPScript.hookURL, "osie-url", "", "[http] URL where OSIE (HookOS) images are located")
 	fs.StringVar(&c.ipxeHTTPScript.tinkServer, "tink-server", "", "[http] IP:Port for the Tink server")
 	fs.BoolVar(&c.ipxeHTTPScript.tinkServerUseTLS, "tink-server-tls", false, "[http] use TLS for Tink server")

--- a/cmd/smee/flag_test.go
+++ b/cmd/smee/flag_test.go
@@ -100,6 +100,7 @@ FLAGS
   -dhcp-ip-for-packet                 [dhcp] IP address to use in DHCP packets (opt 54, etc) (default "%[1]v")
   -dhcp-syslog-ip                     [dhcp] Syslog server IP address to use in DHCP packets (opt 7) (default "%[1]v")
   -dhcp-tftp-ip                       [dhcp] TFTP server IP address to use in DHCP packets (opt 66, etc) (default "%[1]v:69")
+  -disable-discover-trusted-proxies   [http] disable discovery of trusted proxies from Kubernetes, only available for the Kubernetes backend (default "false")
   -extra-kernel-args                  [http] extra set of kernel args (k=v k=v) that are appended to the kernel cmdline iPXE script
   -http-addr                          [http] local IP:Port to listen on for iPXE HTTP script requests (default "%[1]v:80")
   -http-ipxe-binary-enabled           [http] enable iPXE HTTP binary server (default "true")

--- a/go.mod
+++ b/go.mod
@@ -13,8 +13,8 @@ require (
 	github.com/packethost/xff v0.0.0-20190305172552-d3e9190c41b3
 	github.com/peterbourgon/ff/v3 v3.4.0
 	github.com/prometheus/client_golang v1.17.0
-	github.com/tinkerbell/dhcp v0.0.0-20231207155719-b3c8a31c34f9
-	github.com/tinkerbell/ipxedust v0.0.0-20231214161425-b49091211c4a
+	github.com/tinkerbell/dhcp v0.0.0-20231215222245-f5112b96a67c
+	github.com/tinkerbell/ipxedust v0.0.0-20231215220341-a535c5deb47a
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.46.1
 	go.opentelemetry.io/otel v1.21.0
 	go.opentelemetry.io/otel/trace v1.21.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/tinkerbell/smee
 
-go 1.20
+go 1.21
+
+toolchain go1.21.2
 
 require (
 	github.com/equinix-labs/otel-init-go v0.0.9
@@ -18,6 +20,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.21.0
 	go.uber.org/zap v1.26.0
 	golang.org/x/sync v0.5.0
+	k8s.io/apimachinery v0.29.0
 	k8s.io/client-go v0.29.0
 )
 
@@ -93,7 +96,6 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.29.0 // indirect
-	k8s.io/apimachinery v0.29.0 // indirect
 	k8s.io/klog/v2 v2.110.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20231206194836-bf4651e18aa8 // indirect
 	k8s.io/utils v0.0.0-20231127182322-b307cd553661 // indirect

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.21.0
 	go.uber.org/zap v1.26.0
 	golang.org/x/sync v0.5.0
+	k8s.io/api v0.29.0
 	k8s.io/apimachinery v0.29.0
 	k8s.io/client-go v0.29.0
 )
@@ -31,6 +32,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
+	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.7.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
@@ -95,7 +97,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.29.0 // indirect
 	k8s.io/klog/v2 v2.110.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20231206194836-bf4651e18aa8 // indirect
 	k8s.io/utils v0.0.0-20231127182322-b307cd553661 // indirect

--- a/go.sum
+++ b/go.sum
@@ -73,6 +73,7 @@ github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 h1:K6RDEckDVWvDI9JAJYCmNdQXq6neHJOYx3V6jnqNEec=
+github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/uuid v1.5.0 h1:1p67kYwdtXjb0gL0BPiP1Av9wiZPo5A8z2cWkTZ+eyU=
 github.com/google/uuid v1.5.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.18.1 h1:6UKoz5ujsI55KNpsJH3UwCq3T8kKbZwNZBNPuTTje8U=
@@ -163,6 +164,7 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/tinkerbell/dhcp v0.0.0-20231207155719-b3c8a31c34f9 h1:kESuyF0DXYE63Q7UMCmBkGqKOTzcqBGK8O0XGdnbHVc=
 github.com/tinkerbell/dhcp v0.0.0-20231207155719-b3c8a31c34f9/go.mod h1:Hsk+IlFnEywO5f4u0ecP7vrX5o73ZkDv8as9MDUOrD4=
 github.com/tinkerbell/ipxedust v0.0.0-20231214161425-b49091211c4a h1:2GQKbt9nBEdMFraRHF2t3l/WtNYjGS81nrXOz1UWVsc=
@@ -191,6 +193,7 @@ go.opentelemetry.io/otel/trace v1.21.0/go.mod h1:LGbsEB0f9LGjN+OZaQQ26sohbOmiMR+
 go.opentelemetry.io/proto/otlp v1.0.0 h1:T0TX0tmXU8a3CbNXzEKGeU5mIVOdf0oykP+u2lIVU/I=
 go.opentelemetry.io/proto/otlp v1.0.0/go.mod h1:Sy6pihPLfYHkr3NkUbEhGHFhINUSI/v80hjKIs5JXpM=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.uber.org/zap v1.26.0 h1:sI7k6L95XOKS281NhVKOFCUNIvv9e0w4BF8N3u+tCRo=
@@ -254,6 +257,7 @@ golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/tools v0.16.0 h1:GO788SKMRunPIBCXiQyo2AaexLstOrVhuAL5YwsckQM=
+golang.org/x/tools v0.16.0/go.mod h1:kYVVN6I1mBNoB1OX+noeBjbRk4IUEPa7JJ+TJMEooJ0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -263,6 +267,7 @@ gomodules.xyz/jsonpatch/v2 v2.4.0/go.mod h1:AH3dM2RI6uoBZxn3LVrfvJ3E0/9dG4cSrbuB
 google.golang.org/appengine v1.6.8 h1:IhEN5q69dyKagZPYMSdIjS2HqprW324FRQZJcGqPAsM=
 google.golang.org/appengine v1.6.8/go.mod h1:1jJ3jBArFh5pcgW8gCtRJnepW8FzD1V44FJffLiz/Ds=
 google.golang.org/genproto v0.0.0-20231211222908-989df2bf70f3 h1:1hfbdAfFbkmpg41000wDVqr7jUpK/Yo+LPnIxxGzmkg=
+google.golang.org/genproto v0.0.0-20231211222908-989df2bf70f3/go.mod h1:5RBcpGRxr25RbDzY5w+dmaqpSEvl8Gwl1x2CICf60ic=
 google.golang.org/genproto/googleapis/api v0.0.0-20231212172506-995d672761c0 h1:s1w3X6gQxwrLEpxnLd/qXTVLgQE2yXwaOaoa6IlY/+o=
 google.golang.org/genproto/googleapis/api v0.0.0-20231212172506-995d672761c0/go.mod h1:CAny0tYF+0/9rmDB9fahA9YLzX3+AEVl1qXbv5hhj6c=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20231212172506-995d672761c0 h1:/jFB8jK5R3Sq3i/lmeZO0cATSzFfZaJq1J2Euan3XKU=

--- a/go.sum
+++ b/go.sum
@@ -165,10 +165,10 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/tinkerbell/dhcp v0.0.0-20231207155719-b3c8a31c34f9 h1:kESuyF0DXYE63Q7UMCmBkGqKOTzcqBGK8O0XGdnbHVc=
-github.com/tinkerbell/dhcp v0.0.0-20231207155719-b3c8a31c34f9/go.mod h1:Hsk+IlFnEywO5f4u0ecP7vrX5o73ZkDv8as9MDUOrD4=
-github.com/tinkerbell/ipxedust v0.0.0-20231214161425-b49091211c4a h1:2GQKbt9nBEdMFraRHF2t3l/WtNYjGS81nrXOz1UWVsc=
-github.com/tinkerbell/ipxedust v0.0.0-20231214161425-b49091211c4a/go.mod h1:zrFXKJHUplvuggD9MzSQuZldQZU4CLter7QYqSLiiE4=
+github.com/tinkerbell/dhcp v0.0.0-20231215222245-f5112b96a67c h1:3DP2/hZ4ew/H6OT3don45xM55W/Og7NYID7x0NZIBtA=
+github.com/tinkerbell/dhcp v0.0.0-20231215222245-f5112b96a67c/go.mod h1:BZr9oLvt55h9XhrCC7/83+3ap5lH/n8MeX+rsDQAX2U=
+github.com/tinkerbell/ipxedust v0.0.0-20231215220341-a535c5deb47a h1:BNbuuQp8m/L0eS9BLToKx1KQSuK/RvUuzSOXVuFKruI=
+github.com/tinkerbell/ipxedust v0.0.0-20231215220341-a535c5deb47a/go.mod h1:zrFXKJHUplvuggD9MzSQuZldQZU4CLter7QYqSLiiE4=
 github.com/tinkerbell/tink v0.9.0 h1:W7X/OEmhyYXE/kPVu1U31fpugVHoc2qsAvBtsZ7mkDg=
 github.com/tinkerbell/tink v0.9.0/go.mod h1:r8gDvx/Y+GEFeT9xwKa14ULrkMre8mYmH3/E9VbUkEw=
 github.com/u-root/uio v0.0.0-20230305220412-3e8cd9d6bf63 h1:YcojQL98T/OO+rybuzn2+5KrD5dBwXIvYBvQ2cD3Avg=

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,7 @@ github.com/emicklei/go-restful/v3 v3.11.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRr
 github.com/equinix-labs/otel-init-go v0.0.9 h1:hdh0Qifs1vzFnaN6UpJz0pO6A6ZejXjvkEFi8OGTfpE=
 github.com/equinix-labs/otel-init-go v0.0.9/go.mod h1:5h8apPuPWz/KaMvAb3d0HoPEisQrUnqPmkc2T5SSpX4=
 github.com/evanphx/json-patch v5.6.0+incompatible h1:jBYDEEiFBPxA0v50tFdvOzQQTCvpL6mnFh5mB2/l16U=
+github.com/evanphx/json-patch v5.6.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.7.0 h1:nJqP7uwL84RJInrohHfW0Fx3awjbm8qZeFv0nW9SYGc=
 github.com/evanphx/json-patch/v5 v5.7.0/go.mod h1:VNkHZ/282BpEyt/tObQO8s5CMPmYYq14uClGH4abBuQ=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
@@ -44,6 +45,7 @@ github.com/go-openapi/swag v0.22.3/go.mod h1:UzaqsxGiab7freDnrUUra0MwWfN/q7tE4j+
 github.com/go-openapi/swag v0.22.4 h1:QLMzNJnMGPRNDCbySlcj1x01tzU8/9LTTL9hZZZogBU=
 github.com/go-openapi/swag v0.22.4/go.mod h1:UzaqsxGiab7freDnrUUra0MwWfN/q7tE4j+VcZ0yl14=
 github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
+github.com/go-playground/assert/v2 v2.2.0/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/oXslEjJA=
 github.com/go-playground/locales v0.14.1/go.mod h1:hxrqLVvrK65+Rwrd5Fc6F2O76J/NuW9t0sjnWqG1slY=
 github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJnYK9S473LQFuzCbDbfSFY=
@@ -51,6 +53,7 @@ github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91
 github.com/go-playground/validator/v10 v10.16.0 h1:x+plE831WK4vaKHO/jpgUGsvLKIqRRkz6M78GuJAfGE=
 github.com/go-playground/validator/v10 v10.16.0/go.mod h1:9iXMNT7sEkjXb0I+enO7QXmzG6QCsPWY4zveKFVRSyU=
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
+github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572/go.mod h1:9Pwr4B2jHnOSGXyyzV8ROjYa2ojvAY6HCGYYfMoC3Ls=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
@@ -89,6 +92,7 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -106,7 +110,9 @@ github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D
 github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0 h1:jWpvCLoY8Z/e3VKvlsiIGKtc+UG6U5vzxaoagmhXfyg=
 github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0/go.mod h1:QUyp042oQthUoa9bqDv0ER0wrtXnBruoNd7aNjkbP+k=
 github.com/mdlayher/packet v1.1.2 h1:3Up1NG6LZrsgDVn6X4L9Ge/iyRyxFEFD9o6Pr3Q1nQY=
+github.com/mdlayher/packet v1.1.2/go.mod h1:GEu1+n9sG5VtiRE4SydOmX5GTwyyYlteZiFU+x0kew4=
 github.com/mdlayher/socket v0.4.1 h1:eM9y2/jlbs1M615oshPQOHZzj6R6wMT7bX5NPiQvn2U=
+github.com/mdlayher/socket v0.4.1/go.mod h1:cAqeGjoufqdxWkD7DkpyS+wcefOtmu5OQ8KuoJGIReA=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -115,12 +121,15 @@ github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjY
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/onsi/ginkgo/v2 v2.13.0 h1:0jY9lJquiL8fcf3M4LAXN5aMlS/b2BV86HFFPCPMgE4=
+github.com/onsi/ginkgo/v2 v2.13.0/go.mod h1:TE309ZR8s5FsKKpuB1YAQYBzCaAfUgatB/xlT/ETL/o=
 github.com/onsi/gomega v1.29.0 h1:KIA/t2t5UBzoirT4H9tsML45GEbo3ouUnBHsCfD2tVg=
+github.com/onsi/gomega v1.29.0/go.mod h1:9sxs+SwGrKI0+PWe4Fxa9tFQQBG5xSsSbMXOI8PPpoQ=
 github.com/packethost/xff v0.0.0-20190305172552-d3e9190c41b3 h1:QcUVLV3NdkCVv4DxQkhgkxTsRvuXn+ZuSqD93mQYouc=
 github.com/packethost/xff v0.0.0-20190305172552-d3e9190c41b3/go.mod h1:nt3WBqCaQsbnxYVBoB4pF+F584z9PjdSVm29iu4gIBg=
 github.com/peterbourgon/ff/v3 v3.4.0 h1:QBvM/rizZM1cB0p0lGMdmR7HxZeI/ZrBWB4DqLkMUBc=
 github.com/peterbourgon/ff/v3 v3.4.0/go.mod h1:zjJVUhx+twciwfDl0zBcFzl4dW8axCRyXE/eKY9RztQ=
 github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5 h1:Ii+DKncOVM8Cu1Hc+ETb5K+23HdAMvESYE3ZJ5b5cMI=
+github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5/go.mod h1:iIss55rKnNBTvrwdmkUpLnDpZoAHvWaiq5+iMmen4AE=
 github.com/pierrec/lz4/v4 v4.1.14/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pierrec/lz4/v4 v4.1.19 h1:tYLzDnjDXh9qIxSTKHwXwOYmm9d887Y7Y1ZkyXYHAN4=
 github.com/pierrec/lz4/v4 v4.1.19/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
@@ -139,6 +148,7 @@ github.com/prometheus/common v0.45.0/go.mod h1:YJmSTw9BoKxJplESWWxlbyttQR4uaEcGy
 github.com/prometheus/procfs v0.12.0 h1:jluTpSng7V9hY0O2R9DzzJHYb2xULk9VTR1V1R/k6Bo=
 github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3cnaOZAZEfOo=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
+github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/rs/xid v1.5.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.31.0 h1:FcTR3NnLWW+NnTwwhFWiJSZr4ECLpqCm6QsEnyvbV4A=
 github.com/rs/zerolog v1.31.0/go.mod h1:/7mN4D5sKwJLZQ2b/znpjC3/GQWY/xaDXUM0kKWRHss=
@@ -249,6 +259,7 @@ golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gomodules.xyz/jsonpatch/v2 v2.4.0 h1:Ci3iUJyx9UeRx7CeFN8ARgGbkESwJK+KB9lLcWxY/Zw=
+gomodules.xyz/jsonpatch/v2 v2.4.0/go.mod h1:AH3dM2RI6uoBZxn3LVrfvJ3E0/9dG4cSrbuBJT4moAY=
 google.golang.org/appengine v1.6.8 h1:IhEN5q69dyKagZPYMSdIjS2HqprW324FRQZJcGqPAsM=
 google.golang.org/appengine v1.6.8/go.mod h1:1jJ3jBArFh5pcgW8gCtRJnepW8FzD1V44FJffLiz/Ds=
 google.golang.org/genproto v0.0.0-20231211222908-989df2bf70f3 h1:1hfbdAfFbkmpg41000wDVqr7jUpK/Yo+LPnIxxGzmkg=
@@ -276,11 +287,13 @@ gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 k8s.io/api v0.29.0 h1:NiCdQMY1QOp1H8lfRyeEf8eOwV6+0xA6XEE44ohDX2A=
 k8s.io/api v0.29.0/go.mod h1:sdVmXoz2Bo/cb77Pxi71IPTSErEW32xa4aXwKH7gfBA=
 k8s.io/apiextensions-apiserver v0.28.3 h1:Od7DEnhXHnHPZG+W9I97/fSQkVpVPQx2diy+2EtmY08=
+k8s.io/apiextensions-apiserver v0.28.3/go.mod h1:NE1XJZ4On0hS11aWWJUTNkmVB03j9LM7gJSisbRt8Lc=
 k8s.io/apimachinery v0.29.0 h1:+ACVktwyicPz0oc6MTMLwa2Pw3ouLAfAon1wPLtG48o=
 k8s.io/apimachinery v0.29.0/go.mod h1:eVBxQ/cwiJxH58eK/jd/vAk4mrxmVlnpBH5J2GbMeis=
 k8s.io/client-go v0.29.0 h1:KmlDtFcrdUzOYrBhXHgKw5ycWzc3ryPX5mQe0SkG3y8=
 k8s.io/client-go v0.29.0/go.mod h1:yLkXH4HKMAywcrD82KMSmfYg2DlE8mepPR4JGSo5n38=
 k8s.io/component-base v0.28.3 h1:rDy68eHKxq/80RiMb2Ld/tbH8uAE75JdCqJyi6lXMzI=
+k8s.io/component-base v0.28.3/go.mod h1:fDJ6vpVNSk6cRo5wmDa6eKIG7UlIQkaFmZN2fYgIUD8=
 k8s.io/klog/v2 v2.110.1 h1:U/Af64HJf7FcwMcXyKm2RPM22WZzyR7OSpYj5tg3cL0=
 k8s.io/klog/v2 v2.110.1/go.mod h1:YGtd1984u+GgbuZ7e08/yBuAfKLSO0+uR1Fhi6ExXjo=
 k8s.io/kube-openapi v0.0.0-20231206194836-bf4651e18aa8 h1:vzKzxN5uyJZLY8HL1/OovW7BJefnsBIWt8T7Gjh2boQ=

--- a/shell.nix
+++ b/shell.nix
@@ -2,9 +2,9 @@ let _pkgs = import <nixpkgs> { };
 in { pkgs ? import (_pkgs.fetchFromGitHub {
   owner = "NixOS";
   repo = "nixpkgs";
-  #branch@date: nixpkgs-unstable@2023-03-11T16:44:21-05:00
-  rev = "8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8";
-  sha256 = "17v6wigks04x1d63a2wcd7cc4z9ca6qr0f4xvw1pdw83f8a3c0nj";
+  #branch@date: nixpkgs-unstable@2023-10-08T09:04:33+02:00
+  rev = "9957cd48326fe8dbd52fdc50dd2502307f188b0d";
+  sha256 = "1l2hq1n1jl2l64fdcpq3jrfphaz10sd1cpsax3xdya0xgsncgcsi";
 }) { } }:
 
 with pkgs;
@@ -13,7 +13,7 @@ mkShell {
   buildInputs = [
     git
     gnumake
-    go_1_20
+    go_1_21
     nixfmt
     nodePackages.prettier
     perl


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
They will eliminate issues from users having to determine the trusted proxies. We've seen issues where the command we provided in the Helm chart doesn't accurately get the pod CIDRs from a cluster. Incorporating this into the Helm chart was tried, but ultimately not possible without extra ordinary effort and a lot of unneeded code to maintain. This functionality can be disabled if desired. By default we run auto discovery.

This will help simplify the deployment of Smee in the Helm Chart.

Also, move go.mod to Go 1.21. This is because when developing with Go 1.21 and `go mod tidy` will update the `go.mod` file.

Dependency updates for tinkerbell/dhcp provide a fix for dhcp relays and the `giaddr`.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #382 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
