### PR TITLE
Remove toolchain from go.mod

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
         run: |
           # fixes "write /run/user/1001/355792648: no space left on device" error
           sudo mount -o remount,size=3G /run/user/1001 || true
-          nix-shell --run 'go get -t ./... && go mod tidy'
+          nix-shell --run 'go get -t ./... && go mod tidy' shell.nix
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/tinkerbell/smee
 
 go 1.21
 
-toolchain go1.21.2
-
 require (
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/ghodss/yaml v1.0.0


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
This causes ci and dependabot issues. Also needed to use the `shell.nix` file in the CI "Fetch Deps" or newer versions of Go get used and cause changes to the go.mod.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
