### PR TITLE
Ipxe hot fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,27 +97,31 @@ FLAGS
   -backend-kube-namespace             [backend] an optional Kubernetes namespace override to query hardware data from, kube backend only
   -dhcp-addr                          [dhcp] local IP:Port to listen on for DHCP requests (default "0.0.0.0:67")
   -dhcp-enabled                       [dhcp] enable DHCP server (default "true")
-  -dhcp-http-ipxe-binary-url          [dhcp] HTTP iPXE binaries URL to use in DHCP packets (default "http://172.17.0.2:8080/ipxe/")
+  -dhcp-http-ipxe-binary-url          [dhcp] HTTP iPXE binaries URL to use in DHCP packets (default "http://172.17.0.3:8080/ipxe/")
   -dhcp-http-ipxe-script-prepend-mac  [dhcp] prepend the hardware MAC address to iPXE script URL base, http://1.2.3.4/auto.ipxe -> http://1.2.3.4/40:15:ff:89:cc:0e/auto.ipxe (default "true")
-  -dhcp-http-ipxe-script-url          [dhcp] HTTP iPXE script URL to use in DHCP packets (default "http://172.17.0.2/auto.ipxe")
+  -dhcp-http-ipxe-script-url          [dhcp] HTTP iPXE script URL to use in DHCP packets (default "http://172.17.0.3/auto.ipxe")
   -dhcp-iface                         [dhcp] interface to bind to for DHCP requests
-  -dhcp-ip-for-packet                 [dhcp] IP address to use in DHCP packets (opt 54, etc) (default "172.17.0.2")
+  -dhcp-ip-for-packet                 [dhcp] IP address to use in DHCP packets (opt 54, etc) (default "172.17.0.3")
   -dhcp-mode                          [dhcp] DHCP mode (reservation, proxy) (default "reservation")
-  -dhcp-syslog-ip                     [dhcp] Syslog server IP address to use in DHCP packets (opt 7) (default "172.17.0.2")
-  -dhcp-tftp-ip                       [dhcp] TFTP server IP address to use in DHCP packets (opt 66, etc) (default "172.17.0.2:69")
+  -dhcp-syslog-ip                     [dhcp] Syslog server IP address to use in DHCP packets (opt 7) (default "172.17.0.3")
+  -dhcp-tftp-ip                       [dhcp] TFTP server IP address to use in DHCP packets (opt 66, etc) (default "172.17.0.3:69")
   -disable-discover-trusted-proxies   [http] disable discovery of trusted proxies from Kubernetes, only available for the Kubernetes backend (default "false")
   -extra-kernel-args                  [http] extra set of kernel args (k=v k=v) that are appended to the kernel cmdline iPXE script
-  -http-addr                          [http] local IP:Port to listen on for iPXE HTTP script requests (default "172.17.0.2:80")
+  -http-addr                          [http] local IP:Port to listen on for iPXE HTTP script requests (default "172.17.0.3:80")
   -http-ipxe-binary-enabled           [http] enable iPXE HTTP binary server (default "true")
   -http-ipxe-script-enabled           [http] enable iPXE HTTP script server (default "true")
+  -ipxe-script-retries                [http] number of retries to attempt when fetching kernel and initrd files in the iPXE script (default "0")
+  -ipxe-script-retry-delay            [http] delay (in seconds) between retries when fetching kernel and initrd files in the iPXE script (default "2")
   -osie-url                           [http] URL where OSIE (HookOS) images are located
   -tink-server                        [http] IP:Port for the Tink server
   -tink-server-tls                    [http] use TLS for Tink server (default "false")
   -trusted-proxies                    [http] comma separated list of trusted proxies in CIDR notation
-  -syslog-addr                        [syslog] local IP:Port to listen on for Syslog messages (default "172.17.0.2:514")
+  -otel-endpoint                      [otel] OpenTelemetry collector endpoint
+  -otel-insecure                      [otel] OpenTelemetry collector insecure (default "true")
+  -syslog-addr                        [syslog] local IP:Port to listen on for Syslog messages (default "172.17.0.3:514")
   -syslog-enabled                     [syslog] enable Syslog server(receiver) (default "true")
   -ipxe-script-patch                  [tftp/http] iPXE script fragment to patch into served iPXE binaries served via TFTP or HTTP
-  -tftp-addr                          [tftp] local IP:Port to listen on for iPXE TFTP binary requests (default "172.17.0.2:69")
+  -tftp-addr                          [tftp] local IP:Port to listen on for iPXE TFTP binary requests (default "172.17.0.3:69")
   -tftp-block-size                    [tftp] TFTP block size a value between 512 (the default block size for TFTP) and 65456 (the max size a UDP packet payload can be) (default "512")
   -tftp-enabled                       [tftp] enable iPXE TFTP binary server) (default "true")
   -tftp-timeout                       [tftp] iPXE TFTP binary server requests timeout (default "5s")

--- a/cmd/smee/flag.go
+++ b/cmd/smee/flag.go
@@ -107,6 +107,7 @@ func ipxeHTTPScriptFlags(c *config, fs *flag.FlagSet) {
 	fs.StringVar(&c.ipxeHTTPScript.tinkServer, "tink-server", "", "[http] IP:Port for the Tink server")
 	fs.BoolVar(&c.ipxeHTTPScript.tinkServerUseTLS, "tink-server-tls", false, "[http] use TLS for Tink server")
 	fs.IntVar(&c.ipxeHTTPScript.retries, "ipxe-script-retries", 0, "[http] number of retries to attempt when fetching kernel and initrd files in the iPXE script")
+	fs.IntVar(&c.ipxeHTTPScript.retryDelay, "ipxe-script-retry-delay", 2, "[http] delay (in seconds) between retries when fetching kernel and initrd files in the iPXE script")
 }
 
 func dhcpFlags(c *config, fs *flag.FlagSet) {

--- a/cmd/smee/flag_test.go
+++ b/cmd/smee/flag_test.go
@@ -25,8 +25,9 @@ func TestParser(t *testing.T) {
 			enabled: true,
 		},
 		ipxeHTTPScript: ipxeHTTPScript{
-			enabled:  true,
-			bindAddr: "192.168.2.4:80",
+			enabled:    true,
+			bindAddr:   "192.168.2.4:80",
+			retryDelay: 2,
 		},
 		dhcp: dhcpConfig{
 			enabled:           true,
@@ -112,6 +113,7 @@ FLAGS
   -http-ipxe-binary-enabled           [http] enable iPXE HTTP binary server (default "true")
   -http-ipxe-script-enabled           [http] enable iPXE HTTP script server (default "true")
   -ipxe-script-retries                [http] number of retries to attempt when fetching kernel and initrd files in the iPXE script (default "0")
+  -ipxe-script-retry-delay            [http] delay (in seconds) between retries when fetching kernel and initrd files in the iPXE script (default "2")
   -osie-url                           [http] URL where OSIE (HookOS) images are located
   -tink-server                        [http] IP:Port for the Tink server
   -tink-server-tls                    [http] use TLS for Tink server (default "false")

--- a/cmd/smee/main.go
+++ b/cmd/smee/main.go
@@ -84,6 +84,7 @@ type ipxeHTTPScript struct {
 	trustedProxies                string
 	disableDiscoverTrustedProxies bool
 	retries                       int
+	retryDelay                    int
 }
 
 type dhcpConfig struct {
@@ -213,14 +214,15 @@ func main() {
 		}
 
 		jh := script.Handler{
-			Logger:             log,
-			Backend:            br,
-			OSIEURL:            cfg.ipxeHTTPScript.hookURL,
-			ExtraKernelParams:  strings.Split(cfg.ipxeHTTPScript.extraKernelArgs, " "),
-			PublicSyslogFQDN:   cfg.dhcp.syslogIP,
-			TinkServerTLS:      cfg.ipxeHTTPScript.tinkServerUseTLS,
-			TinkServerGRPCAddr: cfg.ipxeHTTPScript.tinkServer,
-			IPXEScriptRetries:  cfg.ipxeHTTPScript.retries,
+			Logger:               log,
+			Backend:              br,
+			OSIEURL:              cfg.ipxeHTTPScript.hookURL,
+			ExtraKernelParams:    strings.Split(cfg.ipxeHTTPScript.extraKernelArgs, " "),
+			PublicSyslogFQDN:     cfg.dhcp.syslogIP,
+			TinkServerTLS:        cfg.ipxeHTTPScript.tinkServerUseTLS,
+			TinkServerGRPCAddr:   cfg.ipxeHTTPScript.tinkServer,
+			IPXEScriptRetries:    cfg.ipxeHTTPScript.retries,
+			IPXEScriptRetryDelay: cfg.ipxeHTTPScript.retryDelay,
 		}
 		// serve ipxe script from the "/" URI.
 		handlers["/"] = jh.HandlerFunc()

--- a/internal/ipxe/script/ipxe.go
+++ b/internal/ipxe/script/ipxe.go
@@ -19,14 +19,15 @@ import (
 )
 
 type Handler struct {
-	Logger             logr.Logger
-	Backend            handler.BackendReader
-	OSIEURL            string
-	ExtraKernelParams  []string
-	PublicSyslogFQDN   string
-	TinkServerTLS      bool
-	TinkServerGRPCAddr string
-	IPXEScriptRetries  int
+	Logger               logr.Logger
+	Backend              handler.BackendReader
+	OSIEURL              string
+	ExtraKernelParams    []string
+	PublicSyslogFQDN     string
+	TinkServerTLS        bool
+	TinkServerGRPCAddr   string
+	IPXEScriptRetries    int
+	IPXEScriptRetryDelay int
 }
 
 type data struct {
@@ -229,6 +230,7 @@ func (h *Handler) defaultScript(span trace.Span, hw data) (string, error) {
 		VLANID:            hw.VLANID,
 		WorkerID:          wID,
 		Retries:           h.IPXEScriptRetries,
+		RetryDelay:        h.IPXEScriptRetryDelay,
 	}
 	if sc := span.SpanContext(); sc.IsSampled() {
 		auto.TraceID = sc.TraceID().String()


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
The iPXE kernel and initrd retries didnt work. This fixes them and adds a configurable retry delay.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested via manual deployment and network booted a machine.


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
