### PR TITLE
Update Raspberry PI mac prefixes:

### DIFF
--- a/internal/dhcp/dhcp.go
+++ b/internal/dhcp/dhcp.go
@@ -57,7 +57,7 @@ var ArchToBootFile = map[iana.Arch]string{
 	iana.EFI_X86_64_HTTP:   "ipxe.efi",
 	iana.EFI_ARM32_HTTP:    "snp.efi",
 	iana.EFI_ARM64_HTTP:    "snp.efi",
-	iana.Arch(41):          "snp.efi", // arm rpiboot: https://www.iana.org/assignments/dhcpv6-parameters/dhcpv6-parameters.xhtml#processor-architecture
+	iana.Arch(41):          "snp.efi", // arm rpiboot (0x29): https://www.iana.org/assignments/dhcpv6-parameters/dhcpv6-parameters.xhtml#processor-architecture
 }
 
 // ErrUnknownArch is used when the PXE client request is from an unknown architecture.
@@ -119,8 +119,9 @@ func isRaspberryPI(mac net.HardwareAddr) bool {
 
 // Arch returns the Arch of the client pulled from DHCP option 93.
 func Arch(d *dhcpv4.DHCPv4) iana.Arch {
-	// if the mac address is from a Raspberry PI, use the Raspberry PI boot file.
-	// Some Raspberry PI's (Raspberry PI 5) report a PXEClient:Arch:00000:UNDI:002001 arch, which is for iana.INTEL_X86PC.
+	// if the mac address is from a Raspberry PI, use the Raspberry PI architecture.
+	// Some Raspberry PI's (Raspberry PI 5) report an option 93 of 0.
+	// This translates to iana.INTEL_X86PC and causes us to map to undionly.kpxe.
 	if isRaspberryPI(d.ClientHWAddr) {
 		return iana.Arch(41)
 	}

--- a/internal/dhcp/dhcp.go
+++ b/internal/dhcp/dhcp.go
@@ -1,6 +1,7 @@
 package dhcp
 
 import (
+	"bytes"
 	"encoding/hex"
 	"fmt"
 	"net"
@@ -95,8 +96,35 @@ func NewInfo(pkt *dhcpv4.DHCPv4) Info {
 	return i
 }
 
+// isRaspberryPI checks if the mac address is from a Raspberry PI by matching prefixes against OUI registrations of the Raspberry Pi Trading Ltd.
+// https://www.netify.ai/resources/macs/brands/raspberry-pi
+// https://udger.com/resources/mac-address-vendor-detail?name=raspberry_pi_foundation
+// https://macaddress.io/statistics/company/27594
+func isRaspberryPI(mac net.HardwareAddr) bool {
+	prefixes := [][]byte{
+		{0xb8, 0x27, 0xeb}, // B8:27:EB
+		{0xdc, 0xa6, 0x32}, // DC:A6:32
+		{0xe4, 0x5f, 0x01}, // E4:5F:01
+		{0x28, 0xcd, 0xc1}, // 28:CD:C1
+		{0xd8, 0x3a, 0xdd}, // D8:3A:DD
+	}
+	for _, prefix := range prefixes {
+		if bytes.HasPrefix(mac, prefix) {
+			return true
+		}
+	}
+
+	return false
+}
+
 // Arch returns the Arch of the client pulled from DHCP option 93.
 func Arch(d *dhcpv4.DHCPv4) iana.Arch {
+	// if the mac address is from a Raspberry PI, use the Raspberry PI boot file.
+	// Some Raspberry PI's (Raspberry PI 5) report a PXEClient:Arch:00000:UNDI:002001 arch, which is for iana.INTEL_X86PC.
+	if isRaspberryPI(d.ClientHWAddr) {
+		return iana.Arch(41)
+	}
+
 	// get option 93 ; arch
 	fwt := d.ClientArch()
 	if len(fwt) == 0 {
@@ -291,10 +319,7 @@ func (i Info) NextServer(ipxeHTTPBinServer *url.URL, ipxeTFTPBinServer netip.Add
 // AddRPIOpt43 adds the Raspberry PI required option43 sub options to an existing opt 43.
 func (i Info) AddRPIOpt43(opts dhcpv4.Options) []byte {
 	// these are suboptions of option43. ref: https://datatracker.ietf.org/doc/html/rfc2132#section-8.4
-	h := strings.ToLower(i.Mac.String())
-	if strings.HasPrefix(h, strings.ToLower("B8:27:EB")) ||
-		strings.HasPrefix(h, strings.ToLower("DC:A6:32")) ||
-		strings.HasPrefix(h, strings.ToLower("E4:5F:01")) {
+	if isRaspberryPI(i.Mac) {
 		// TODO document what these hex strings are and why they are needed.
 		// https://www.raspberrypi.org/documentation/computers/raspberry-pi.html#PXE_OPTION43
 		// tested with Raspberry Pi 4 using UEFI from here: https://github.com/pftf/RPi4/releases/tag/v1.31

--- a/internal/dhcp/dhcp_test.go
+++ b/internal/dhcp/dhcp_test.go
@@ -84,6 +84,10 @@ func TestArch(t *testing.T) {
 			pkt:  &dhcpv4.DHCPv4{Options: dhcpv4.OptionsFromList(dhcpv4.OptClientArch(iana.INTEL_X86PC))},
 			want: iana.INTEL_X86PC,
 		},
+		"raspberry pi": {
+			pkt:  &dhcpv4.DHCPv4{ClientHWAddr: net.HardwareAddr{0xb8, 0x27, 0xeb, 0x00, 0x00, 0x00}},
+			want: iana.Arch(41),
+		},
 		"unknown": {
 			pkt:  &dhcpv4.DHCPv4{Options: dhcpv4.OptionsFromList(dhcpv4.OptClientArch(iana.Arch(255)))},
 			want: iana.Arch(255),
@@ -303,5 +307,29 @@ func TestUserClassString(t *testing.T) {
 	u := UserClass("test")
 	if diff := cmp.Diff("test", u.String()); diff != "" {
 		t.Fatal(diff)
+	}
+}
+
+func TestIsRaspberryPI(t *testing.T) {
+	tests := map[string]struct {
+		mac  net.HardwareAddr
+		want bool
+	}{
+		"not a raspberry pi": {
+			mac:  net.HardwareAddr{0x01, 0x02, 0x03, 0x04, 0x05, 0x06},
+			want: false,
+		},
+		"raspberry pi": {
+			mac:  net.HardwareAddr{0xb8, 0x27, 0xeb, 0x00, 0x00, 0x00},
+			want: true,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := isRaspberryPI(tt.mac)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Fatal(diff)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
There are new mac prefixes for Raspberry PIs. Use mac address to determine Architecture for Raspberry PI's. This is needed because in my testing Raspberry PI 5 identifies itself in DHCP option 93 as an INTEL_X86PC.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
