### PR TITLE
Break out port from most CLI flags:

### DIFF
--- a/cmd/smee/flag.go
+++ b/cmd/smee/flag.go
@@ -87,7 +87,8 @@ func syslogFlags(c *config, fs *flag.FlagSet) {
 
 func tftpFlags(c *config, fs *flag.FlagSet) {
 	fs.BoolVar(&c.tftp.enabled, "tftp-enabled", true, "[tftp] enable iPXE TFTP binary server)")
-	fs.StringVar(&c.tftp.bindAddr, "tftp-addr", detectPublicIPv4(":69"), "[tftp] local IP:Port to listen on for iPXE TFTP binary requests")
+	fs.StringVar(&c.tftp.bindAddr, "tftp-addr", detectPublicIPv4(""), "[tftp] local IP to listen on for iPXE TFTP binary requests")
+	fs.IntVar(&c.tftp.bindPort, "tftp-port", 69, "[tftp] local port to listen on for iPXE TFTP binary requests")
 	fs.DurationVar(&c.tftp.timeout, "tftp-timeout", time.Second*5, "[tftp] iPXE TFTP binary server requests timeout")
 	fs.StringVar(&c.tftp.ipxeScriptPatch, "ipxe-script-patch", "", "[tftp/http] iPXE script fragment to patch into served iPXE binaries served via TFTP or HTTP")
 	fs.IntVar(&c.tftp.blockSize, "tftp-block-size", 512, "[tftp] TFTP block size a value between 512 (the default block size for TFTP) and 65456 (the max size a UDP packet payload can be)")
@@ -99,7 +100,8 @@ func ipxeHTTPBinaryFlags(c *config, fs *flag.FlagSet) {
 
 func ipxeHTTPScriptFlags(c *config, fs *flag.FlagSet) {
 	fs.BoolVar(&c.ipxeHTTPScript.enabled, "http-ipxe-script-enabled", true, "[http] enable iPXE HTTP script server")
-	fs.StringVar(&c.ipxeHTTPScript.bindAddr, "http-addr", detectPublicIPv4(":80"), "[http] local IP:Port to listen on for iPXE HTTP script requests")
+	fs.StringVar(&c.ipxeHTTPScript.bindAddr, "http-addr", detectPublicIPv4(""), "[http] local IP to listen on for iPXE HTTP script requests")
+	fs.IntVar(&c.ipxeHTTPScript.bindPort, "http-port", 8080, "[http] local port to listen on for iPXE HTTP script requests")
 	fs.StringVar(&c.ipxeHTTPScript.extraKernelArgs, "extra-kernel-args", "", "[http] extra set of kernel args (k=v k=v) that are appended to the kernel cmdline iPXE script")
 	fs.StringVar(&c.ipxeHTTPScript.trustedProxies, "trusted-proxies", "", "[http] comma separated list of trusted proxies in CIDR notation")
 	fs.BoolVar(&c.ipxeHTTPScript.disableDiscoverTrustedProxies, "disable-discover-trusted-proxies", false, "[http] disable discovery of trusted proxies from Kubernetes, only available for the Kubernetes backend")
@@ -117,9 +119,16 @@ func dhcpFlags(c *config, fs *flag.FlagSet) {
 	fs.StringVar(&c.dhcp.bindInterface, "dhcp-iface", "", "[dhcp] interface to bind to for DHCP requests")
 	fs.StringVar(&c.dhcp.ipForPacket, "dhcp-ip-for-packet", detectPublicIPv4(""), "[dhcp] IP address to use in DHCP packets (opt 54, etc)")
 	fs.StringVar(&c.dhcp.syslogIP, "dhcp-syslog-ip", detectPublicIPv4(""), "[dhcp] Syslog server IP address to use in DHCP packets (opt 7)")
-	fs.StringVar(&c.dhcp.tftpIP, "dhcp-tftp-ip", detectPublicIPv4(":69"), "[dhcp] TFTP server IP address to use in DHCP packets (opt 66, etc)")
-	fs.StringVar(&c.dhcp.httpIpxeBinaryURL, "dhcp-http-ipxe-binary-url", "http://"+detectPublicIPv4(":8080/ipxe/"), "[dhcp] HTTP iPXE binaries URL to use in DHCP packets")
-	fs.StringVar(&c.dhcp.httpIpxeScript.url, "dhcp-http-ipxe-script-url", "http://"+detectPublicIPv4("/auto.ipxe"), "[dhcp] HTTP iPXE script URL to use in DHCP packets")
+	fs.StringVar(&c.dhcp.tftpIP, "dhcp-tftp-ip", detectPublicIPv4(""), "[dhcp] TFTP server IP address to use in DHCP packets (opt 66, etc)")
+	fs.IntVar(&c.dhcp.tftpPort, "dhcp-tftp-port", 69, "[dhcp] TFTP server port to use in DHCP packets (opt 66, etc)")
+	fs.StringVar(&c.dhcp.httpIpxeBinaryURL.Scheme, "dhcp-http-ipxe-binary-scheme", "http", "[dhcp] HTTP iPXE binaries scheme to use in DHCP packets")
+	fs.StringVar(&c.dhcp.httpIpxeBinaryURL.Host, "dhcp-http-ipxe-binary-host", detectPublicIPv4(""), "[dhcp] HTTP iPXE binaries host or IP to use in DHCP packets")
+	fs.IntVar(&c.dhcp.httpIpxeBinaryURL.Port, "dhcp-http-ipxe-binary-port", 8080, "[dhcp] HTTP iPXE binaries port to use in DHCP packets")
+	fs.StringVar(&c.dhcp.httpIpxeBinaryURL.Path, "dhcp-http-ipxe-binary-path", "/ipxe/", "[dhcp] HTTP iPXE binaries path to use in DHCP packets")
+	fs.StringVar(&c.dhcp.httpIpxeScript.Scheme, "dhcp-http-ipxe-script-scheme", "http", "[dhcp] HTTP iPXE script scheme to use in DHCP packets")
+	fs.StringVar(&c.dhcp.httpIpxeScript.Host, "dhcp-http-ipxe-script-host", detectPublicIPv4(""), "[dhcp] HTTP iPXE script host or IP to use in DHCP packets")
+	fs.IntVar(&c.dhcp.httpIpxeScript.Port, "dhcp-http-ipxe-script-port", 8080, "[dhcp] HTTP iPXE script port to use in DHCP packets")
+	fs.StringVar(&c.dhcp.httpIpxeScript.Path, "dhcp-http-ipxe-script-path", "/auto.ipxe", "[dhcp] HTTP iPXE script path to use in DHCP packets")
 	fs.BoolVar(&c.dhcp.httpIpxeScript.injectMacAddress, "dhcp-http-ipxe-script-prepend-mac", true, "[dhcp] prepend the hardware MAC address to iPXE script URL base, http://1.2.3.4/auto.ipxe -> http://1.2.3.4/40:15:ff:89:cc:0e/auto.ipxe")
 }
 

--- a/cmd/smee/flag_test.go
+++ b/cmd/smee/flag_test.go
@@ -19,26 +19,39 @@ func TestParser(t *testing.T) {
 			blockSize: 512,
 			enabled:   true,
 			timeout:   5 * time.Second,
-			bindAddr:  "192.168.2.4:69",
+			bindAddr:  "192.168.2.4",
+			bindPort:  69,
 		},
 		ipxeHTTPBinary: ipxeHTTPBinary{
 			enabled: true,
 		},
 		ipxeHTTPScript: ipxeHTTPScript{
 			enabled:    true,
-			bindAddr:   "192.168.2.4:80",
+			bindAddr:   "192.168.2.4",
+			bindPort:   8080,
 			retryDelay: 2,
 		},
 		dhcp: dhcpConfig{
-			enabled:           true,
-			mode:              "reservation",
-			bindAddr:          "0.0.0.0:67",
-			ipForPacket:       "192.168.2.4",
-			syslogIP:          "192.168.2.4",
-			tftpIP:            "192.168.2.4:69",
-			httpIpxeBinaryURL: "http://192.168.2.4:8080/ipxe/",
+			enabled:     true,
+			mode:        "reservation",
+			bindAddr:    "0.0.0.0:67",
+			ipForPacket: "192.168.2.4",
+			syslogIP:    "192.168.2.4",
+			tftpIP:      "192.168.2.4",
+			tftpPort:    69,
+			httpIpxeBinaryURL: urlBuilder{
+				Scheme: "http",
+				Host:   "192.168.2.4",
+				Port:   8080,
+				Path:   "/ipxe/",
+			},
 			httpIpxeScript: httpIpxeScript{
-				url:              "http://192.168.2.4/auto.ipxe",
+				urlBuilder: urlBuilder{
+					Scheme: "http",
+					Host:   "192.168.2.4",
+					Port:   8080,
+					Path:   "/auto.ipxe",
+				},
 				injectMacAddress: true,
 			},
 		},
@@ -56,13 +69,13 @@ func TestParser(t *testing.T) {
 	args := []string{
 		"-log-level", "info",
 		"-syslog-addr", "192.168.2.4:514",
-		"-tftp-addr", "192.168.2.4:69",
-		"-http-addr", "192.168.2.4:80",
+		"-tftp-addr", "192.168.2.4",
+		"-http-addr", "192.168.2.4",
 		"-dhcp-ip-for-packet", "192.168.2.4",
 		"-dhcp-syslog-ip", "192.168.2.4",
-		"-dhcp-tftp-ip", "192.168.2.4:69",
-		"-dhcp-http-ipxe-binary-url", "http://192.168.2.4:8080/ipxe/",
-		"-dhcp-http-ipxe-script-url", "http://192.168.2.4/auto.ipxe",
+		"-dhcp-tftp-ip", "192.168.2.4",
+		"-dhcp-http-ipxe-binary-host", "192.168.2.4",
+		"-dhcp-http-ipxe-script-host", "192.168.2.4",
 	}
 	cli := newCLI(&got, fs)
 	cli.Parse(args)
@@ -76,6 +89,7 @@ func TestParser(t *testing.T) {
 		cmp.AllowUnexported(dhcpBackends{}),
 		cmp.AllowUnexported(httpIpxeScript{}),
 		cmp.AllowUnexported(otelConfig{}),
+		cmp.AllowUnexported(urlBuilder{}),
 	}
 	if diff := cmp.Diff(want, got, opts); diff != "" {
 		t.Fatal(diff)
@@ -99,19 +113,27 @@ FLAGS
   -backend-kube-namespace             [backend] an optional Kubernetes namespace override to query hardware data from, kube backend only
   -dhcp-addr                          [dhcp] local IP:Port to listen on for DHCP requests (default "0.0.0.0:67")
   -dhcp-enabled                       [dhcp] enable DHCP server (default "true")
-  -dhcp-http-ipxe-binary-url          [dhcp] HTTP iPXE binaries URL to use in DHCP packets (default "http://%[1]v:8080/ipxe/")
+  -dhcp-http-ipxe-binary-host         [dhcp] HTTP iPXE binaries host or IP to use in DHCP packets (default "%[1]v")
+  -dhcp-http-ipxe-binary-path         [dhcp] HTTP iPXE binaries path to use in DHCP packets (default "/ipxe/")
+  -dhcp-http-ipxe-binary-port         [dhcp] HTTP iPXE binaries port to use in DHCP packets (default "8080")
+  -dhcp-http-ipxe-binary-scheme       [dhcp] HTTP iPXE binaries scheme to use in DHCP packets (default "http")
+  -dhcp-http-ipxe-script-host         [dhcp] HTTP iPXE script host or IP to use in DHCP packets (default "%[1]v")
+  -dhcp-http-ipxe-script-path         [dhcp] HTTP iPXE script path to use in DHCP packets (default "/auto.ipxe")
+  -dhcp-http-ipxe-script-port         [dhcp] HTTP iPXE script port to use in DHCP packets (default "8080")
   -dhcp-http-ipxe-script-prepend-mac  [dhcp] prepend the hardware MAC address to iPXE script URL base, http://1.2.3.4/auto.ipxe -> http://1.2.3.4/40:15:ff:89:cc:0e/auto.ipxe (default "true")
-  -dhcp-http-ipxe-script-url          [dhcp] HTTP iPXE script URL to use in DHCP packets (default "http://%[1]v/auto.ipxe")
+  -dhcp-http-ipxe-script-scheme       [dhcp] HTTP iPXE script scheme to use in DHCP packets (default "http")
   -dhcp-iface                         [dhcp] interface to bind to for DHCP requests
   -dhcp-ip-for-packet                 [dhcp] IP address to use in DHCP packets (opt 54, etc) (default "%[1]v")
   -dhcp-mode                          [dhcp] DHCP mode (reservation, proxy) (default "reservation")
   -dhcp-syslog-ip                     [dhcp] Syslog server IP address to use in DHCP packets (opt 7) (default "%[1]v")
-  -dhcp-tftp-ip                       [dhcp] TFTP server IP address to use in DHCP packets (opt 66, etc) (default "%[1]v:69")
+  -dhcp-tftp-ip                       [dhcp] TFTP server IP address to use in DHCP packets (opt 66, etc) (default "%[1]v")
+  -dhcp-tftp-port                     [dhcp] TFTP server port to use in DHCP packets (opt 66, etc) (default "69")
   -disable-discover-trusted-proxies   [http] disable discovery of trusted proxies from Kubernetes, only available for the Kubernetes backend (default "false")
   -extra-kernel-args                  [http] extra set of kernel args (k=v k=v) that are appended to the kernel cmdline iPXE script
-  -http-addr                          [http] local IP:Port to listen on for iPXE HTTP script requests (default "%[1]v:80")
+  -http-addr                          [http] local IP to listen on for iPXE HTTP script requests (default "%[1]v")
   -http-ipxe-binary-enabled           [http] enable iPXE HTTP binary server (default "true")
   -http-ipxe-script-enabled           [http] enable iPXE HTTP script server (default "true")
+  -http-port                          [http] local port to listen on for iPXE HTTP script requests (default "8080")
   -ipxe-script-retries                [http] number of retries to attempt when fetching kernel and initrd files in the iPXE script (default "0")
   -ipxe-script-retry-delay            [http] delay (in seconds) between retries when fetching kernel and initrd files in the iPXE script (default "2")
   -osie-url                           [http] URL where OSIE (HookOS) images are located
@@ -123,9 +145,10 @@ FLAGS
   -syslog-addr                        [syslog] local IP:Port to listen on for Syslog messages (default "%[1]v:514")
   -syslog-enabled                     [syslog] enable Syslog server(receiver) (default "true")
   -ipxe-script-patch                  [tftp/http] iPXE script fragment to patch into served iPXE binaries served via TFTP or HTTP
-  -tftp-addr                          [tftp] local IP:Port to listen on for iPXE TFTP binary requests (default "%[1]v:69")
+  -tftp-addr                          [tftp] local IP to listen on for iPXE TFTP binary requests (default "%[1]v")
   -tftp-block-size                    [tftp] TFTP block size a value between 512 (the default block size for TFTP) and 65456 (the max size a UDP packet payload can be) (default "512")
   -tftp-enabled                       [tftp] enable iPXE TFTP binary server) (default "true")
+  -tftp-port                          [tftp] local port to listen on for iPXE TFTP binary requests (default "69")
   -tftp-timeout                       [tftp] iPXE TFTP binary server requests timeout (default "5s")
 `, defaultIP)
 

--- a/cmd/smee/main.go
+++ b/cmd/smee/main.go
@@ -64,6 +64,7 @@ type syslogConfig struct {
 
 type tftp struct {
 	bindAddr        string
+	bindPort        int
 	blockSize       int
 	enabled         bool
 	ipxeScriptPatch string
@@ -77,6 +78,7 @@ type ipxeHTTPBinary struct {
 type ipxeHTTPScript struct {
 	enabled                       bool
 	bindAddr                      string
+	bindPort                      int
 	extraKernelArgs               string
 	hookURL                       string
 	tinkServer                    string
@@ -95,12 +97,20 @@ type dhcpConfig struct {
 	ipForPacket       string
 	syslogIP          string
 	tftpIP            string
-	httpIpxeBinaryURL string
+	tftpPort          int
+	httpIpxeBinaryURL urlBuilder
 	httpIpxeScript    httpIpxeScript
 }
 
+type urlBuilder struct {
+	Scheme string
+	Host   string
+	Port   int
+	Path   string
+}
+
 type httpIpxeScript struct {
-	url string
+	urlBuilder
 	// injectMacAddress will prepend the hardware mac address to the ipxe script URL file name.
 	// For example: http://1.2.3.4/my/loc/auto.ipxe -> http://1.2.3.4/my/loc/40:15:ff:89:cc:0e/auto.ipxe
 	// Setting this to false is useful when you are not using the auto.ipxe script in Smee.
@@ -164,7 +174,8 @@ func main() {
 			EnableTFTPSinglePort: true,
 		}
 		tftpServer.EnableTFTPSinglePort = true
-		if ip, err := netip.ParseAddrPort(cfg.tftp.bindAddr); err == nil {
+		addr := fmt.Sprintf("%s:%d", cfg.tftp.bindAddr, cfg.tftp.bindPort)
+		if ip, err := netip.ParseAddrPort(addr); err == nil {
 			tftpServer.TFTP = ipxedust.ServerSpec{
 				Disabled:  false,
 				Addr:      ip,
@@ -173,7 +184,7 @@ func main() {
 				BlockSize: cfg.tftp.blockSize,
 			}
 			// start the ipxe binary tftp server
-			log.Info("starting tftp server", "bind_addr", cfg.tftp.bindAddr)
+			log.Info("starting tftp server", "bind_addr", addr)
 			g.Go(func() error {
 				return tftpServer.ListenAndServe(ctx)
 			})
@@ -237,9 +248,10 @@ func main() {
 			Logger:         log,
 			TrustedProxies: tp,
 		}
-		log.Info("serving http", "addr", cfg.ipxeHTTPScript.bindAddr, "trusted_proxies", tp)
+		bindAddr := fmt.Sprintf("%s:%d", cfg.ipxeHTTPScript.bindAddr, cfg.ipxeHTTPScript.bindPort)
+		log.Info("serving http", "addr", bindAddr, "trusted_proxies", tp)
 		g.Go(func() error {
-			return httpServer.ServeHTTP(ctx, cfg.ipxeHTTPScript.bindAddr, handlers)
+			return httpServer.ServeHTTP(ctx, bindAddr, handlers)
 		})
 	}
 
@@ -282,16 +294,30 @@ func (c *config) dhcpHandler(ctx context.Context, log logr.Logger) (server.Handl
 	if err != nil {
 		return nil, fmt.Errorf("invalid bind address: %w", err)
 	}
-	tftpIP, err := netip.ParseAddrPort(c.dhcp.tftpIP)
+	tftpIP, err := netip.ParseAddrPort(fmt.Sprintf("%s:%d", c.dhcp.tftpIP, c.dhcp.tftpPort))
 	if err != nil {
 		return nil, fmt.Errorf("invalid tftp address for DHCP server: %w", err)
 	}
-	httpBinaryURL, err := url.Parse(c.dhcp.httpIpxeBinaryURL)
-	if err != nil || httpBinaryURL == nil {
+	httpBinaryURL := &url.URL{
+		Scheme: c.dhcp.httpIpxeBinaryURL.Scheme,
+		Host:   fmt.Sprintf("%s:%d", c.dhcp.httpIpxeBinaryURL.Host, c.dhcp.httpIpxeBinaryURL.Port),
+		Path:   c.dhcp.httpIpxeBinaryURL.Path,
+	}
+	if _, err := url.Parse(httpBinaryURL.String()); err != nil {
 		return nil, fmt.Errorf("invalid http ipxe binary url: %w", err)
 	}
-	httpScriptURL, err := url.Parse(c.dhcp.httpIpxeScript.url)
-	if err != nil || httpScriptURL == nil {
+
+	httpScriptURL := &url.URL{
+		Scheme: c.dhcp.httpIpxeScript.Scheme,
+		Host: func() string {
+			if c.dhcp.httpIpxeScript.Port == 80 {
+				return c.dhcp.httpIpxeScript.Host
+			}
+			return fmt.Sprintf("%s:%d", c.dhcp.httpIpxeScript.Host, c.dhcp.httpIpxeScript.Port)
+		}(),
+		Path: c.dhcp.httpIpxeScript.Path,
+	}
+	if _, err := url.Parse(httpScriptURL.String()); err != nil {
 		return nil, fmt.Errorf("invalid http ipxe script url: %w", err)
 	}
 	ipxeScript := func(d *dhcpv4.DHCPv4) *url.URL {


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
This allows detectPublicIPv4 to be used and still allow the ports to be customized. This will be helpful in a few scenarios, one is when Smee is deployed with `hostNetwork: true` in Kubernetes.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #475 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
