### PR TITLE
Split out syslog port

### DIFF
--- a/cmd/smee/flag.go
+++ b/cmd/smee/flag.go
@@ -82,7 +82,8 @@ func countFlags(fs *flag.FlagSet) (n int) {
 
 func syslogFlags(c *config, fs *flag.FlagSet) {
 	fs.BoolVar(&c.syslog.enabled, "syslog-enabled", true, "[syslog] enable Syslog server(receiver)")
-	fs.StringVar(&c.syslog.bindAddr, "syslog-addr", detectPublicIPv4(":514"), "[syslog] local IP:Port to listen on for Syslog messages")
+	fs.StringVar(&c.syslog.bindAddr, "syslog-addr", detectPublicIPv4(""), "[syslog] local IP to listen on for Syslog messages")
+	fs.IntVar(&c.syslog.bindPort, "syslog-port", 514, "[syslog] local port to listen on for Syslog messages")
 }
 
 func tftpFlags(c *config, fs *flag.FlagSet) {

--- a/cmd/smee/flag.go
+++ b/cmd/smee/flag.go
@@ -82,13 +82,13 @@ func countFlags(fs *flag.FlagSet) (n int) {
 
 func syslogFlags(c *config, fs *flag.FlagSet) {
 	fs.BoolVar(&c.syslog.enabled, "syslog-enabled", true, "[syslog] enable Syslog server(receiver)")
-	fs.StringVar(&c.syslog.bindAddr, "syslog-addr", detectPublicIPv4(""), "[syslog] local IP to listen on for Syslog messages")
+	fs.StringVar(&c.syslog.bindAddr, "syslog-addr", detectPublicIPv4(), "[syslog] local IP to listen on for Syslog messages")
 	fs.IntVar(&c.syslog.bindPort, "syslog-port", 514, "[syslog] local port to listen on for Syslog messages")
 }
 
 func tftpFlags(c *config, fs *flag.FlagSet) {
 	fs.BoolVar(&c.tftp.enabled, "tftp-enabled", true, "[tftp] enable iPXE TFTP binary server)")
-	fs.StringVar(&c.tftp.bindAddr, "tftp-addr", detectPublicIPv4(""), "[tftp] local IP to listen on for iPXE TFTP binary requests")
+	fs.StringVar(&c.tftp.bindAddr, "tftp-addr", detectPublicIPv4(), "[tftp] local IP to listen on for iPXE TFTP binary requests")
 	fs.IntVar(&c.tftp.bindPort, "tftp-port", 69, "[tftp] local port to listen on for iPXE TFTP binary requests")
 	fs.DurationVar(&c.tftp.timeout, "tftp-timeout", time.Second*5, "[tftp] iPXE TFTP binary server requests timeout")
 	fs.StringVar(&c.tftp.ipxeScriptPatch, "ipxe-script-patch", "", "[tftp/http] iPXE script fragment to patch into served iPXE binaries served via TFTP or HTTP")
@@ -101,7 +101,7 @@ func ipxeHTTPBinaryFlags(c *config, fs *flag.FlagSet) {
 
 func ipxeHTTPScriptFlags(c *config, fs *flag.FlagSet) {
 	fs.BoolVar(&c.ipxeHTTPScript.enabled, "http-ipxe-script-enabled", true, "[http] enable iPXE HTTP script server")
-	fs.StringVar(&c.ipxeHTTPScript.bindAddr, "http-addr", detectPublicIPv4(""), "[http] local IP to listen on for iPXE HTTP script requests")
+	fs.StringVar(&c.ipxeHTTPScript.bindAddr, "http-addr", detectPublicIPv4(), "[http] local IP to listen on for iPXE HTTP script requests")
 	fs.IntVar(&c.ipxeHTTPScript.bindPort, "http-port", 8080, "[http] local port to listen on for iPXE HTTP script requests")
 	fs.StringVar(&c.ipxeHTTPScript.extraKernelArgs, "extra-kernel-args", "", "[http] extra set of kernel args (k=v k=v) that are appended to the kernel cmdline iPXE script")
 	fs.StringVar(&c.ipxeHTTPScript.trustedProxies, "trusted-proxies", "", "[http] comma separated list of trusted proxies in CIDR notation")
@@ -118,16 +118,16 @@ func dhcpFlags(c *config, fs *flag.FlagSet) {
 	fs.StringVar(&c.dhcp.mode, "dhcp-mode", "reservation", "[dhcp] DHCP mode (reservation, proxy)")
 	fs.StringVar(&c.dhcp.bindAddr, "dhcp-addr", "0.0.0.0:67", "[dhcp] local IP:Port to listen on for DHCP requests")
 	fs.StringVar(&c.dhcp.bindInterface, "dhcp-iface", "", "[dhcp] interface to bind to for DHCP requests")
-	fs.StringVar(&c.dhcp.ipForPacket, "dhcp-ip-for-packet", detectPublicIPv4(""), "[dhcp] IP address to use in DHCP packets (opt 54, etc)")
-	fs.StringVar(&c.dhcp.syslogIP, "dhcp-syslog-ip", detectPublicIPv4(""), "[dhcp] Syslog server IP address to use in DHCP packets (opt 7)")
-	fs.StringVar(&c.dhcp.tftpIP, "dhcp-tftp-ip", detectPublicIPv4(""), "[dhcp] TFTP server IP address to use in DHCP packets (opt 66, etc)")
+	fs.StringVar(&c.dhcp.ipForPacket, "dhcp-ip-for-packet", detectPublicIPv4(), "[dhcp] IP address to use in DHCP packets (opt 54, etc)")
+	fs.StringVar(&c.dhcp.syslogIP, "dhcp-syslog-ip", detectPublicIPv4(), "[dhcp] Syslog server IP address to use in DHCP packets (opt 7)")
+	fs.StringVar(&c.dhcp.tftpIP, "dhcp-tftp-ip", detectPublicIPv4(), "[dhcp] TFTP server IP address to use in DHCP packets (opt 66, etc)")
 	fs.IntVar(&c.dhcp.tftpPort, "dhcp-tftp-port", 69, "[dhcp] TFTP server port to use in DHCP packets (opt 66, etc)")
 	fs.StringVar(&c.dhcp.httpIpxeBinaryURL.Scheme, "dhcp-http-ipxe-binary-scheme", "http", "[dhcp] HTTP iPXE binaries scheme to use in DHCP packets")
-	fs.StringVar(&c.dhcp.httpIpxeBinaryURL.Host, "dhcp-http-ipxe-binary-host", detectPublicIPv4(""), "[dhcp] HTTP iPXE binaries host or IP to use in DHCP packets")
+	fs.StringVar(&c.dhcp.httpIpxeBinaryURL.Host, "dhcp-http-ipxe-binary-host", detectPublicIPv4(), "[dhcp] HTTP iPXE binaries host or IP to use in DHCP packets")
 	fs.IntVar(&c.dhcp.httpIpxeBinaryURL.Port, "dhcp-http-ipxe-binary-port", 8080, "[dhcp] HTTP iPXE binaries port to use in DHCP packets")
 	fs.StringVar(&c.dhcp.httpIpxeBinaryURL.Path, "dhcp-http-ipxe-binary-path", "/ipxe/", "[dhcp] HTTP iPXE binaries path to use in DHCP packets")
 	fs.StringVar(&c.dhcp.httpIpxeScript.Scheme, "dhcp-http-ipxe-script-scheme", "http", "[dhcp] HTTP iPXE script scheme to use in DHCP packets")
-	fs.StringVar(&c.dhcp.httpIpxeScript.Host, "dhcp-http-ipxe-script-host", detectPublicIPv4(""), "[dhcp] HTTP iPXE script host or IP to use in DHCP packets")
+	fs.StringVar(&c.dhcp.httpIpxeScript.Host, "dhcp-http-ipxe-script-host", detectPublicIPv4(), "[dhcp] HTTP iPXE script host or IP to use in DHCP packets")
 	fs.IntVar(&c.dhcp.httpIpxeScript.Port, "dhcp-http-ipxe-script-port", 8080, "[dhcp] HTTP iPXE script port to use in DHCP packets")
 	fs.StringVar(&c.dhcp.httpIpxeScript.Path, "dhcp-http-ipxe-script-path", "/auto.ipxe", "[dhcp] HTTP iPXE script path to use in DHCP packets")
 	fs.BoolVar(&c.dhcp.httpIpxeScript.injectMacAddress, "dhcp-http-ipxe-script-prepend-mac", true, "[dhcp] prepend the hardware MAC address to iPXE script URL base, http://1.2.3.4/auto.ipxe -> http://1.2.3.4/40:15:ff:89:cc:0e/auto.ipxe")
@@ -170,13 +170,13 @@ func newCLI(cfg *config, fs *flag.FlagSet) *ffcli.Command {
 	}
 }
 
-func detectPublicIPv4(extra string) string {
+func detectPublicIPv4() string {
 	ip, err := autoDetectPublicIPv4()
 	if err != nil {
 		return ""
 	}
 
-	return fmt.Sprintf("%v%v", ip.String(), extra)
+	return ip.String()
 }
 
 func autoDetectPublicIPv4() (net.IP, error) {

--- a/cmd/smee/flag_test.go
+++ b/cmd/smee/flag_test.go
@@ -13,7 +13,8 @@ func TestParser(t *testing.T) {
 	want := config{
 		syslog: syslogConfig{
 			enabled:  true,
-			bindAddr: "192.168.2.4:514",
+			bindAddr: "192.168.2.4",
+			bindPort: 514,
 		},
 		tftp: tftp{
 			blockSize: 512,
@@ -68,7 +69,7 @@ func TestParser(t *testing.T) {
 	fs := flag.NewFlagSet(name, flag.ContinueOnError)
 	args := []string{
 		"-log-level", "info",
-		"-syslog-addr", "192.168.2.4:514",
+		"-syslog-addr", "192.168.2.4",
 		"-tftp-addr", "192.168.2.4",
 		"-http-addr", "192.168.2.4",
 		"-dhcp-ip-for-packet", "192.168.2.4",
@@ -142,8 +143,9 @@ FLAGS
   -trusted-proxies                    [http] comma separated list of trusted proxies in CIDR notation
   -otel-endpoint                      [otel] OpenTelemetry collector endpoint
   -otel-insecure                      [otel] OpenTelemetry collector insecure (default "true")
-  -syslog-addr                        [syslog] local IP:Port to listen on for Syslog messages (default "%[1]v:514")
+  -syslog-addr                        [syslog] local IP to listen on for Syslog messages (default "%[1]v")
   -syslog-enabled                     [syslog] enable Syslog server(receiver) (default "true")
+  -syslog-port                        [syslog] local port to listen on for Syslog messages (default "514")
   -ipxe-script-patch                  [tftp/http] iPXE script fragment to patch into served iPXE binaries served via TFTP or HTTP
   -tftp-addr                          [tftp] local IP to listen on for iPXE TFTP binary requests (default "%[1]v")
   -tftp-block-size                    [tftp] TFTP block size a value between 512 (the default block size for TFTP) and 65456 (the max size a UDP packet payload can be) (default "512")

--- a/cmd/smee/flag_test.go
+++ b/cmd/smee/flag_test.go
@@ -98,7 +98,7 @@ func TestParser(t *testing.T) {
 }
 
 func TestCustomUsageFunc(t *testing.T) {
-	defaultIP := detectPublicIPv4("")
+	defaultIP := detectPublicIPv4()
 	want := fmt.Sprintf(`Smee is the DHCP and Network boot service for use in the Tinkerbell stack.
 
 USAGE

--- a/cmd/smee/main.go
+++ b/cmd/smee/main.go
@@ -60,6 +60,7 @@ type config struct {
 type syslogConfig struct {
 	enabled  bool
 	bindAddr string
+	bindPort int
 }
 
 type tftp struct {
@@ -154,9 +155,10 @@ func main() {
 	g, ctx := errgroup.WithContext(ctx)
 	// syslog
 	if cfg.syslog.enabled {
-		log.Info("starting syslog server", "bind_addr", cfg.syslog.bindAddr)
+		addr := fmt.Sprintf("%s:%d", cfg.syslog.bindAddr, cfg.syslog.bindPort)
+		log.Info("starting syslog server", "bind_addr", addr)
 		g.Go(func() error {
-			if err := syslog.StartReceiver(ctx, log, cfg.syslog.bindAddr, 1); err != nil {
+			if err := syslog.StartReceiver(ctx, log, addr, 1); err != nil {
 				log.Error(err, "syslog server failure")
 				return err
 			}


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->

This allows customizing the syslog port without having to customize the auto-detected ip. This is inline with the other similar changes just made.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
