### PR TITLE
Fix nil pointer error:

### DIFF
--- a/internal/dhcp/handler/proxy/proxy.go
+++ b/internal/dhcp/handler/proxy/proxy.go
@@ -187,7 +187,14 @@ func (h *Handler) Handle(ctx context.Context, conn *ipv4.PacketConn, dp data.Pac
 	// check the backend, if PXE is NOT allowed, set the boot file name to "/<mac address>/not-allowed"
 	_, n, err := h.Backend.GetByMac(ctx, dp.Pkt.ClientHWAddr)
 	if err != nil || (n != nil && !n.AllowNetboot) {
-		log.V(1).Info("Ignoring packet", "error", err.Error(), "netbootAllowed", n.AllowNetboot)
+		l := log.V(1)
+		if err != nil {
+			l.WithValues("error", err.Error())
+		}
+		if n != nil {
+			l.WithValues("netbootAllowed", n.AllowNetboot)
+		}
+		l.Info("Ignoring packet")
 		span.SetStatus(codes.Ok, "netboot not allowed")
 		return
 	}


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
When in proxyDHCP mode if AllowNetboot is false Smee would panic because of this log line. This resolves the issue.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #482

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
