### PR TITLE
Add static ipam to kernel parameters for ISO patching:

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,9 +149,9 @@ FLAGS
   -tink-server                        [http] IP:Port for the Tink server
   -tink-server-tls                    [http] use TLS for Tink server (default "false")
   -trusted-proxies                    [http] comma separated list of trusted proxies in CIDR notation
-  -iso-enabled                        [iso] enable serving Hook as an iso (default "false")
-  -iso-magic-string                   [iso] the string pattern to match for in the source iso, if not set the default from HookOS is used
-  -iso-url                            [iso] the url for source iso before binary patching
+  -iso-enabled                        [iso] enable patching an OSIE ISO (default "false")
+  -iso-magic-string                   [iso] the string pattern to match for in the source ISO, defaults to the one defined in HookOS
+  -iso-static-ipam-enabled            [iso] enable static IPAM for HookOS (default "false")
   -otel-endpoint                      [otel] OpenTelemetry collector endpoint
   -otel-insecure                      [otel] OpenTelemetry collector insecure (default "true")
   -syslog-addr                        [syslog] local IP to listen on for Syslog messages (default "172.17.0.3")

--- a/cmd/smee/flag.go
+++ b/cmd/smee/flag.go
@@ -154,9 +154,10 @@ func otelFlags(c *config, fs *flag.FlagSet) {
 }
 
 func isoFlags(c *config, fs *flag.FlagSet) {
-	fs.BoolVar(&c.iso.enabled, "iso-enabled", false, "[iso] enable serving Hook as an iso")
-	fs.StringVar(&c.iso.url, "iso-url", "", "[iso] the url for source iso before binary patching")
-	fs.StringVar(&c.iso.magicString, "iso-magic-string", "", "[iso] the string pattern to match for in the source iso, if not set the default from HookOS is used")
+	fs.BoolVar(&c.iso.enabled, "iso-enabled", false, "[iso] enable patching an OSIE ISO")
+	fs.StringVar(&c.iso.url, "iso-url", "", "[iso] an ISO source URL target for patching")
+	fs.StringVar(&c.iso.magicString, "iso-magic-string", "", "[iso] the string pattern to match for in the source ISO, defaults to the one defined in HookOS")
+	fs.BoolVar(&c.iso.staticIPAMEnabled, "iso-static-ipam-enabled", false, "[iso] enable static IPAM for HookOS")
 }
 
 func setFlags(c *config, fs *flag.FlagSet) {

--- a/cmd/smee/flag_test.go
+++ b/cmd/smee/flag_test.go
@@ -153,9 +153,10 @@ FLAGS
   -tink-server-insecure-tls           [http] use insecure TLS for Tink server (default "false")
   -tink-server-tls                    [http] use TLS for Tink server (default "false")
   -trusted-proxies                    [http] comma separated list of trusted proxies in CIDR notation
-  -iso-enabled                        [iso] enable serving Hook as an iso (default "false")
-  -iso-magic-string                   [iso] the string pattern to match for in the source iso, if not set the default from HookOS is used
-  -iso-url                            [iso] the url for source iso before binary patching
+  -iso-enabled                        [iso] enable patching an OSIE ISO (default "false")
+  -iso-magic-string                   [iso] the string pattern to match for in the source ISO, defaults to the one defined in HookOS
+  -iso-static-ipam-enabled            [iso] enable static IPAM for HookOS (default "false")
+  -iso-url                            [iso] an ISO source URL target for patching
   -otel-endpoint                      [otel] OpenTelemetry collector endpoint
   -otel-insecure                      [otel] OpenTelemetry collector insecure (default "true")
   -syslog-addr                        [syslog] local IP to listen on for Syslog messages (default "%[1]v")

--- a/cmd/smee/main.go
+++ b/cmd/smee/main.go
@@ -142,9 +142,10 @@ type otelConfig struct {
 }
 
 type isoConfig struct {
-	enabled     bool
-	url         string
-	magicString string
+	enabled           bool
+	url               string
+	magicString       string
+	staticIPAMEnabled bool
 }
 
 func main() {
@@ -262,6 +263,7 @@ func main() {
 			Syslog:             cfg.dhcp.syslogIP,
 			TinkServerTLS:      cfg.ipxeHTTPScript.tinkServerUseTLS,
 			TinkServerGRPCAddr: cfg.ipxeHTTPScript.tinkServer,
+			StaticIPAMEnabled:  cfg.iso.staticIPAMEnabled,
 			MagicString: func() string {
 				if cfg.iso.magicString == "" {
 					return magicString

--- a/internal/iso/iso.go
+++ b/internal/iso/iso.go
@@ -351,6 +351,13 @@ func parseIPAM(d *data.DHCP) string {
 
 		return ""
 	}()
+	ipam[7] = func() string {
+		if len(d.DomainSearch) > 0 {
+			return strings.Join(d.DomainSearch, ",")
+		}
+
+		return ""
+	}()
 	ipam[8] = func() string {
 		var ntp []string
 		for _, e := range d.NTPServers {

--- a/internal/iso/iso.go
+++ b/internal/iso/iso.go
@@ -257,9 +257,16 @@ func (h *Handler) constructPatch(console, mac string, d *data.DHCP) string {
 	grpcAuthority := fmt.Sprintf("grpc_authority=%s", h.TinkServerGRPCAddr)
 	tinkerbellTLS := fmt.Sprintf("tinkerbell_tls=%v", h.TinkServerTLS)
 	workerID := fmt.Sprintf("worker_id=%s", mac)
+	vlanID := func() string {
+		if d != nil {
+			return fmt.Sprintf("vlan_id=%s", d.VLANID)
+		}
+		return ""
+	}()
+	hwAddr := fmt.Sprintf("hw_addr=%s", mac)
 	ipam := parseIPAM(d)
 
-	return strings.Join([]string{strings.Join(h.ExtraKernelParams, " "), console, syslogHost, grpcAuthority, tinkerbellTLS, workerID, ipam}, " ")
+	return strings.Join([]string{strings.Join(h.ExtraKernelParams, " "), console, vlanID, hwAddr, syslogHost, grpcAuthority, tinkerbellTLS, workerID, ipam}, " ")
 }
 
 func getMAC(urlPath string) (net.HardwareAddr, error) {

--- a/internal/iso/iso_test.go
+++ b/internal/iso/iso_test.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/netip"
 	"net/url"
 	"os"
 	"testing"
@@ -193,4 +194,40 @@ func (m *mockBackend) GetByIP(context.Context, net.IP) (*data.DHCP, *data.Netboo
 		Facility: "test",
 	}
 	return d, n, nil
+}
+
+func TestParseIPAM(t *testing.T) {
+	tests := map[string]struct {
+		input *data.DHCP
+		want  string
+	}{
+		"empty": {},
+		"only MAC": {
+			input: &data.DHCP{MACAddress: net.HardwareAddr{0xde, 0xed, 0xbe, 0xef, 0xfe, 0xed}},
+			want:  "ipam=de-ed-be-ef-fe-ed::::::::",
+		},
+		"everything": {
+			input: &data.DHCP{
+				MACAddress:     net.HardwareAddr{0xde, 0xed, 0xbe, 0xef, 0xfe, 0xed},
+				IPAddress:      netip.AddrFrom4([4]byte{127, 0, 0, 1}),
+				SubnetMask:     net.IPv4Mask(255, 255, 255, 0),
+				DefaultGateway: netip.AddrFrom4([4]byte{127, 0, 0, 2}),
+				NameServers:    []net.IP{{1, 1, 1, 1}, {4, 4, 4, 4}},
+				Hostname:       "myhost",
+				NTPServers:     []net.IP{{129, 6, 15, 28}, {129, 6, 15, 29}},
+				DomainSearch:   []string{"example.com", "example.org"},
+				VLANID:         "400",
+			},
+			want: "ipam=de-ed-be-ef-fe-ed:400:127.0.0.1:255.255.255.0:127.0.0.2:myhost:1.1.1.1,4.4.4.4:example.com,example.org:129.6.15.28,129.6.15.29",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := parseIPAM(tt.input)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Fatalf("diff: %v", diff)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
This adds optional static IPAM data to kernel parameters when patching an ISO.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
