### PR TITLE
Fix how we check for OSIE.BaseURL:

### DIFF
--- a/internal/ipxe/script/ipxe.go
+++ b/internal/ipxe/script/ipxe.go
@@ -287,7 +287,7 @@ func (h *Handler) defaultScript(span trace.Span, hw data) (string, error) {
 		Retries:               h.IPXEScriptRetries,
 		RetryDelay:            h.IPXEScriptRetryDelay,
 	}
-	if hw.OSIE.BaseURL != nil {
+	if hw.OSIE.BaseURL != nil && hw.OSIE.BaseURL.String() != "" {
 		auto.DownloadURL = hw.OSIE.BaseURL.String()
 	}
 	if hw.OSIE.Kernel != "" {


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
The object that gets returned from Kubernetes seems to always come back non-nil. So we need to also check if the string is empty.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
