### PR TITLE
fix: use text/template instead of html/template in auto.go to prevent HTML escaping

### DIFF
--- a/internal/ipxe/script/auto.go
+++ b/internal/ipxe/script/auto.go
@@ -2,7 +2,7 @@ package script
 
 import (
 	"bytes"
-	"html/template"
+	"text/template"
 )
 
 func GenerateTemplate(d any, script string) (string, error) {


### PR DESCRIPTION
## Description

This PR changes the template package import from html/template to text/template in the iPXE script generation code (auto.go). The motivation is to prevent automatic HTML escaping of special characters (like +), which breaks iPXE scripts when base64-encoded content is included.

## Why is this needed

Using html/template escapes characters such as + into HTML entities (&#43;), causing malformed iPXE scripts and boot failures. Switching to text/template preserves the exact literal content required.

## How Has This Been Tested?

Manually generated iPXE scripts with base64-encoded strings using both html/template and text/template.
The text/template output preserves literal + characters:

While html/template produces escaped output:
```
#!ipxe
dhcp
set secret-base64 H4sIAAAAA&#43;//////==&#43;/
boot
```

Using text/template:
```
#!ipxe
dhcp
set secret-base64 H4sIAAAAA+//////==+/
boot
```

## How are existing users impacted? What migration steps/scripts do we need?

No migration required. This is a fix to script generation to prevent escaping bugs.

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (Not necessary)
- [x] added unit or e2e tests (Not necessary)
- [x] provided instructions on how to upgrade (Not necessary)
